### PR TITLE
command string fix for newer wkhtmltopdf

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -16,7 +16,7 @@ class WickedPdf
   end
 
   def pdf_from_string(string, options=nil)
-    command_for_stdin_stdout = "#{@exe_path} #{options} - - -q" # -q for no errors on stdout
+    command_for_stdin_stdout = "#{@exe_path} #{options} -q - -" # -q for no errors on stdout
     p "*"*15 + command_for_stdin_stdout + "*"*15 if RAILS_ENV == 'development'
     Open3.popen3(command_for_stdin_stdout) do |stdin, stdout, stderr|
       stdin.write(string)


### PR DESCRIPTION
Here's a patch for newer wkhtmltopdf builds (tested on 0.10.0_beta5 on heroku) -- it wants the "-q" to appear before the "-" stdin/stdout args apparently.  This should be a backwards-compatible fix.

The message I get with 0.10.0_beta5 + heroku:

> -q specified in incorrect location

Moving the "-q" works fine on a local install of 0.9.9 on OS X 10.6.4.
