### PR TITLE
javascript_src_tag has been removed in rails 3.1

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -11,7 +11,8 @@ module WickedPdfHelper
   end
 
   def wicked_pdf_javascript_src_tag(jsfile, options={})
-    javascript_src_tag "file://#{Rails.root.join('public','javascripts',jsfile)}", options
+    source = "file://#{Rails.root.join('public','javascripts',jsfile)}"
+    content_tag("script", "", { "type" => Mime::JS, "src" => path_to_javascript(source) }.merge(options))
   end
 
   def wicked_pdf_javascript_include_tag(*sources)


### PR DESCRIPTION
using `wicked_pdf_javascript_include_tag` stops working in rails 3.1.1

```
ActionView::Template::Error (undefined method `javascript_src_tag' for #<#<Class:0x000001072f33b8>:0x000001076e6498>):
```

i changed `wicked_pdf_javascript_include_tag` to stop using the removed `javascript_src_tag` method.
