### PR TITLE
fix for wkhtmltopdf path with spaces

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -23,7 +23,7 @@ class WickedPdf
   end
 
   def pdf_from_string(string, options={})
-    command = "#{@exe_path} #{parse_options(options)} -q - - " # -q for no errors on stdout
+    command = "\"#{@exe_path}\" #{parse_options(options)} -q - - " # -q for no errors on stdout
     p "*"*15 + command + "*"*15 unless defined?(Rails) and Rails.env != 'development'
     pdf, err = Open3.popen3(command) do |stdin, stdout, stderr|
       stdin.binmode


### PR DESCRIPTION
After this patch wicked_pdf works also if the wkhtmltopdf path is for example "C:\Program Files\MyApp\wkhtmltopdf.exe" or "/home/me/wicked test/wkhtmltopdf".
