### PR TITLE
Error: undefined method `blank?' for {:header=>nil, :footer=>nil, :layout=>nil}:Hash when not using Rails

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -5,6 +5,7 @@ require 'logger'
 require 'digest/md5'
 require 'open3'
 require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/object/blank'
 
 require 'wicked_pdf_railtie'
 require 'wicked_pdf_tempfile'


### PR DESCRIPTION
lib/wicked_pdf.rb:81 was causing an error because blank? is not a method on ruby's Hash.

This solves that for people who aren't using wicked_pdf as part of a rails project.

I realize that the plugin specifically states that it is for Rails, but this is a fairly minor change to allow it to work with just ActiveSupport.
