### PR TITLE
Add backwards compatibility to Rail 2.0.5

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -24,7 +24,7 @@ class WickedPdf
 
   def pdf_from_string(string, options={})
     command = "\"#{@exe_path}\" #{parse_options(options)} -q - - " # -q for no errors on stdout
-    p "*"*15 + command + "*"*15 unless defined?(Rails) and Rails.env != 'development'
+    p "*"*15 + command + "*"*15 unless defined?(Rails) and defined?(Rails)!="constant" and Rail    s.env != 'development'
     pdf, err = Open3.popen3(command) do |stdin, stdout, stderr|
       stdin.binmode
       stdout.binmode


### PR DESCRIPTION
I know it is old and unsupported but it's what one of our legacy systems is running on. The issue is in Rails 2.0.5 defined?(Rails) returns "constant" not false so this breaks.
