### PR TITLE
Do not register PDF MIME type for Rails 3.2+

### DIFF
--- a/lib/wicked_pdf_railtie.rb
+++ b/lib/wicked_pdf_railtie.rb
@@ -22,7 +22,9 @@ if defined?(Rails)
         else
           ActionView::Base.send :include, WickedPdfHelper
         end
-        Mime::Type.register 'application/pdf', :pdf
+        if Rails::VERSION::MINOR <= 1
+          Mime::Type.register 'application/pdf', :pdf
+        end
       end
     end
 


### PR DESCRIPTION
Loading this gem with Rails 3.2 (just released today) causes an error in ActionDispatch regarding an already initialized constant PDF (because the PDF MIME type is registered by Rails by default now).

Rails 3.2+ registers the PDF mime type by default, per https://gist.github.com/1472145.
