### PR TITLE
options with spaces in their values work now for Windows as well

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -67,7 +67,7 @@ class WickedPdf
       "--#{name.gsub('_', '-')} " + case type
         when :boolean then ""
         when :numeric then value.to_s
-        else "'#{value}'"
+        else "\"#{value}\""
       end + " "
     end
 

--- a/test/wicked_pdf_test.rb
+++ b/test/wicked_pdf_test.rb
@@ -64,7 +64,7 @@ class WickedPdfTest < ActiveSupport::TestCase
 
     [:header, :footer].each do |hf|
       [:center, :font_name, :left, :right].each do |o|
-        assert_equal  "--#{hf.to_s}-#{o.to_s.gsub('_', '-')} 'header_footer'",
+        assert_equal  "--#{hf.to_s}-#{o.to_s.gsub('_', '-')} \"header_footer\"",
                       wp.get_parsed_options(hf => {o => "header_footer"}).strip
       end
 
@@ -75,7 +75,7 @@ class WickedPdfTest < ActiveSupport::TestCase
 
       assert_equal  "--#{hf.to_s}-line",
                     wp.get_parsed_options(hf => {:line => true}).strip
-      assert_equal  "--#{hf.to_s}-html 'http://www.abc.com'",
+      assert_equal  "--#{hf.to_s}-html \"http://www.abc.com\"",
                     wp.get_parsed_options(hf => {:html => {:url => 'http://www.abc.com'}}).strip
     end
   end
@@ -84,7 +84,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     wp = WickedPdf.new
 
     [:font_name, :header_text].each do |o|
-      assert_equal  "--toc-#{o.to_s.gsub('_', '-')} 'toc'",
+      assert_equal  "--toc-#{o.to_s.gsub('_', '-')} \"toc\"",
                     wp.get_parsed_options(:toc => {o => "toc"}).strip
     end
 
@@ -123,7 +123,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     [ :orientation, :page_size, :proxy, :username, :password, :cover, :dpi,
       :encoding, :user_style_sheet
     ].each do |o|
-      assert_equal "--#{o.to_s.gsub('_', '-')} 'opts'", wp.get_parsed_options(o => "opts").strip
+      assert_equal "--#{o.to_s.gsub('_', '-')} \"opts\"", wp.get_parsed_options(o => "opts").strip
     end
 
     [:redirect_delay, :zoom, :page_offset].each do |o|


### PR DESCRIPTION
If you had e.g. :header => { :left => 'My header' }, in Windows pdf could not be generated due to the space in the value. It seems that Windows considers the first single quote being part of the value, which means that the space makes the command invalid.

The single quotes caused also another problem. If you had :header => { :left => 'My-header' }, the command worked but in the pdf you saw 'My-header' with the quotes (not plain My-header).

This patch fixes the both problems. First of all, when there are spaces in the values, the pdf can be generated. Secondly, the output does not contain single quotes, just the text that was wanted.

The fix should have no effect on wicked_pdf behavior in Linux.
