### PR TITLE
Add support for javascript_delay option

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -165,7 +165,8 @@ class WickedPdf
                                     :post], "", :name_value)
         r +=make_options(options, [ :redirect_delay,
                                     :zoom,
-                                    :page_offset], "", :numeric)
+                                    :page_offset,
+                                    :javascript_delay], "", :numeric)
         r +=make_options(options, [ :book,
                                     :default_header,
                                     :disable_javascript,


### PR DESCRIPTION
Hi,

This small patch adds support for the --javascript-delay <msec> option, available in wkhtmltopdf 0.11 (and maybe 0.10, I didn't check).
