### PR TITLE
Improve wkhtmltopdf binary location finder.

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -187,9 +187,9 @@ class WickedPdf
       exe_path ||= begin
         (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
       rescue Exception => e
-        ''
+        nil
       end
       exe_path ||= possible_locations.map{|l| File.expand_path("#{l}/#{EXE_NAME}") }.find{|location| File.exists? location}
-      exe_path
+      exe_path || ''
     end
 end


### PR DESCRIPTION
Sometimes I'm getting this error: 

```
undefined method `chomp' for nil:NilClass
wicked_pdf (0.7.5) lib/wicked_pdf.rb:21:in `initialize'
```

This commit should fix this, also it improves location finding by specifying possible paths.
