### PR TITLE
Fix for when precompiled assets are used with asset_host

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -58,7 +58,7 @@ module WickedPdfHelper
       if Rails.configuration.assets.compile == false
         if ActionController::Base.asset_host
           require 'open-uri'
-          IO.read open(asset_pathname(source))
+          open(asset_pathname(source)) {|f| f.read }
         else
           IO.read(asset_pathname(source))
         end


### PR DESCRIPTION
See #115. This fixes the case when `asset_host` is used (e.g. for CDN), resulting in `asset_path` being an absolute  URL and we have to read from the URL instead
