### PR TITLE
Fixes #114 "undefined method render for module"

### DIFF
--- a/lib/pdf_helper.rb
+++ b/lib/pdf_helper.rb
@@ -3,6 +3,10 @@ module PdfHelper
   require 'wicked_pdf_tempfile'
 
   def self.included(base)
+    # Protect from trying to augment modules that appear
+    # as the result of adding other gems.
+    return if base.class != ActionController::Base
+
     base.class_eval do
       alias_method_chain :render, :wicked_pdf
       alias_method_chain :render_to_string, :wicked_pdf


### PR DESCRIPTION
Just a quick fix for the #114. Some gems make Rails (3.2.2 and 3.2.6 in my case) pass a synthetic Module into the `included` call, and it fails as there are certainly no `render` and `render_to_string` methods in them. Here we check if that's an instance of `ActionController::Base` and work only on it.

Cheers.
