### PR TITLE
Open assets in UTF-8.

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -64,7 +64,7 @@ module WickedPdfHelper
       if Rails.configuration.assets.compile == false
         if ActionController::Base.asset_host
           require 'open-uri'
-          open(asset_pathname(source)) {|f| f.read }
+          open(asset_pathname(source), 'r:UTF-8') {|f| f.read }
         else
           IO.read(asset_pathname(source))
         end


### PR DESCRIPTION
This fix encoding issue when we load assets. Most of the time your assets have ASCII-8BIT encoding while your template is using UTF-8. It creates errors such as "incompatible character encodings: UTF-8 and ASCII-8BIT"

Now we open assets using utf8 encoding.
