### PR TITLE
Fixed asset path for applications using relative_url_root

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -53,7 +53,7 @@ module WickedPdfHelper
           # asset_path returns an absolute URL using asset_host if asset_host is set
           asset_path(source)
         else
-          File.join(Rails.public_path, asset_path(source))
+          File.join(Rails.public_path, asset_path(source).sub(/\A#{Rails.application.config.action_controller.relative_url_root}/, ''))
         end
       else
         Rails.application.assets.find_asset(source).pathname


### PR DESCRIPTION
Apps hosted at subdirectories (using `relative_url_root`) create an incorrect path when using `asset_pathname` because `asset_path` is prepended with  `relative_url_root`. Stripping it off the front of `asset_path` fixes this issue and should not affect apps that do not use `relative_url_root`.
