### PR TITLE
WickedPdfTempfile.new use temp_path argument

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -30,11 +30,12 @@ class WickedPdf
   end
 
   def pdf_from_string(string, options={})
-    string_file = WickedPdfTempfile.new("wicked_pdf.html")
+    temp_path = options.delete(:temp_path)
+    string_file = WickedPdfTempfile.new("wicked_pdf.html", temp_path)    
     string_file.write(string)
     string_file.close
 
-    generated_pdf_file = WickedPdfTempfile.new("wicked_pdf_generated_file.pdf")
+    generated_pdf_file = WickedPdfTempfile.new("wicked_pdf_generated_file.pdf", temp_path)
     command = "\"#{@exe_path}\" #{'-q ' unless on_windows?}#{parse_options(options)} \"file:///#{string_file.path}\" \"#{generated_pdf_file.path}\" " # -q for no errors on stdout
     print_command(command) if in_development_mode?
     err = Open3.popen3(command) do |stdin, stdout, stderr|


### PR DESCRIPTION
You can use pdf_from_string with an option :temp_path. If temp_path available WickedPdfTempfile use this path or set :temp_path as default in WickedPdf configuration 

```
WickedPdf.config = {
  :exe_path => '/usr/bin/wkhtmltopdf',       
  :temp_path => File.join(Rails.root, "tmp")
}
```
