### PR TITLE
use super instead of alias_method_chain

### DIFF
--- a/lib/pdf_helper.rb
+++ b/lib/pdf_helper.rb
@@ -8,30 +8,28 @@ module PdfHelper
     return if base != ActionController::Base
 
     base.class_eval do
-      alias_method_chain :render, :wicked_pdf
-      alias_method_chain :render_to_string, :wicked_pdf
       after_filter :clean_temp_files
     end
   end
 
-  def render_with_wicked_pdf(options = nil, *args, &block)
+  def render(options = nil, *args, &block)
     if options.is_a?(Hash) && options.has_key?(:pdf)
       log_pdf_creation
       options[:basic_auth] = set_basic_auth(options)
       make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
     else
-      render_without_wicked_pdf(options, *args, &block)
+      super
     end
   end
 
-  def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+  def render_to_string(options = nil, *args, &block)
     if options.is_a?(Hash) && options.has_key?(:pdf)
       log_pdf_creation
       options[:basic_auth] = set_basic_auth(options)
       options.delete :pdf
       make_pdf((WickedPdf.config || {}).merge(options))
     else
-      render_to_string_without_wicked_pdf(options, *args, &block)
+      super
     end
   end
 


### PR DESCRIPTION
- alias_method_chain skips some overriding render methods.
  (e.g. remotipart-1.0.2/lib/remotipart/render_overrides.rb)
- options[:pdf] avoids infinite recursive method calls.
