### PR TITLE
Check if logger isn't nil

### DIFF
--- a/lib/pdf_helper.rb
+++ b/lib/pdf_helper.rb
@@ -38,7 +38,7 @@ module PdfHelper
   private
 
     def log_pdf_creation
-      logger.info '*'*15 + 'WICKED' + '*'*15
+      logger.info '*'*15 + 'WICKED' + '*'*15 unless logger.nil?
     end
 
     def set_basic_auth(options={})


### PR DESCRIPTION
When we got config.action_controller.logger set to nil to prevent logging we get error 

``` ruby
undefined method `info' for nil:NilClass
```

which is caused by 

``` ruby
def log_pdf_creation
  logger.info '*'*15 + 'WICKED' + '*'*15
end
```
