### PR TITLE
Fix for precompiled assets when using Proc as asset_host

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -56,9 +56,12 @@ module WickedPdfHelper
 
     private
 
+    # borrowed from actionpack/lib/action_view/helpers/asset_url_helper.rb
+    URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
+
     def asset_pathname(source)
       if Rails.configuration.assets.compile == false
-        if ActionController::Base.asset_host
+        if asset_path(source) =~ URI_REGEXP
           # asset_path returns an absolute URL using asset_host if asset_host is set
           asset_path(source)
         else
@@ -71,7 +74,7 @@ module WickedPdfHelper
 
     def read_asset(source)
       if Rails.configuration.assets.compile == false
-        if ActionController::Base.asset_host
+        if asset_path(source) =~ URI_REGEXP
           require 'open-uri'
           open(asset_pathname(source), 'r:UTF-8') {|f| f.read }
         else


### PR DESCRIPTION
This fixes the case when `asset_host` is used and set to  a Proc to differentiate CDN content from local content.

Scenario: I'm using an `asset_host` to serve assets from a CDN, but I want wicked_pdf to still use locally precompiled assets that are stored in their own pdf sub-directories. This is from my production config:

``` ruby
  cdn_host = "//s3.amazonaws.com/#{ENV['CDN_BUCKET']}"
  config.action_controller.asset_host = Proc.new { |source|
    # pdf-specific assets are in images/pdf/ and stylesheets/pdf/
    source.include?('/pdf/') ? nil : cdn_host
  }
```

This extends the idea behind issue/pull #119, but because my `asset_host` is non-nil, wicked_pdf will incorrectly assume that the `asset_path` for my pdf assets is an absolute path. Instead of checking if `asset_host` is configured, we should check if `asset_path` is actually an absolute URL. My fix is something along these lines matching against `URI_REGEXP`.
