### PR TITLE
Explicitly close and unlink WickedPdfTempfile

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -48,6 +48,9 @@ class WickedPdf
     pdf
   rescue Exception => e
     raise "Failed to execute:\n#{command}\nError: #{e}"
+  ensure
+    string_file.close! if string_file
+    generated_pdf_file.close! if generated_pdf_file
   end
 
   private


### PR DESCRIPTION
[Ruby docs](http://www.ruby-doc.org/stdlib-2.0/libdoc/tempfile/rdoc/Tempfile.html#label-Good+practices) states a good practice when using Tempfile is to explicitly
close and unlink temporary files within an ensure block rather than
relying on the garbage collector.
