### PR TITLE
Rails 4.0 compatibility

### DIFF
--- a/lib/wicked_pdf_railtie.rb
+++ b/lib/wicked_pdf_railtie.rb
@@ -3,7 +3,16 @@ require 'wicked_pdf_helper'
 
 if defined?(Rails)
 
-  if Rails::VERSION::MAJOR == 2
+  if Rails::VERSION::MAJOR == 4
+
+    class WickedRailtie < Rails::Railtie
+      initializer "wicked_pdf.register" do |app|
+        ActionController::Base.send :include, PdfHelper
+        ActionView::Base.send :include, WickedPdfHelper::Assets
+      end
+    end
+
+  elsif Rails::VERSION::MAJOR == 2
 
     unless ActionController::Base.instance_methods.include? "render_with_wicked_pdf"
       ActionController::Base.send :include, PdfHelper


### PR DESCRIPTION
The railtie was checking for Rails 3.0, which is before the asset pipeline
existed by looking at the Rails minor version. This condition also caught 4.0
though.

Rails 4.0 also removed the assets.enabled check, so the Rails 4 initializer is
much simpler
