### PR TITLE
Use binary mode for temporary files when using pdf_from_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,9 @@ pdf = WickedPdf.new.pdf_from_string('<h1>Hello There!</h1>')
 
 # create a pdf from string using templates, layouts and content option for header or footer
 WickedPdf.new.pdf_from_string(
-  render_to_string(
-    :pdf      => "pdf_file.pdf",
-    :template => 'templates/pdf.html.erb',
-    :layout   => 'pdfs/layout_pdf'
-  ), 
+  render_to_string('templates/pdf.html.erb', :layout => 'pdfs/layout_pdf'),
   :footer => {
-    :content => render_to_string(
-      :template => 'templates/pdf_footer.html.erb',
-      :layout   => 'pdfs/layout_pdf'
-    )
+    :content => render_to_string(:layout => 'pdfs/layout_pdf')
   }
 )
   

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -48,6 +48,7 @@ class WickedPdf
 
     temp_path = options.delete(:temp_path)
     string_file = WickedPdfTempfile.new("wicked_pdf.html", temp_path)
+    string_file.binmode
     string_file.write(string)
     string_file.close
     generated_pdf_file = WickedPdfTempfile.new("wicked_pdf_generated_file.pdf", temp_path)


### PR DESCRIPTION
Use binary mode for temporary files when using pdf_from_string (#208)
Updated readme for proper pdf_from_string usage (also related to #208)
