### PR TITLE
javascript_src_tag deprecated in rails 3.2

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -22,7 +22,8 @@ module WickedPdfHelper
 
   def wicked_pdf_javascript_src_tag(jsfile, options={})
     jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
-    javascript_src_tag "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}", options
+    src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
+    content_tag("script", "", { "type" => Mime::JS, "src" => path_to_javascript(src) }.merge(options))
   end
 
   def wicked_pdf_javascript_include_tag(*sources)


### PR DESCRIPTION
javascript_src_tag deprecated in rails 3.2, so just using content tag for things there, oterwise getting error in rails 3.2

http://apidock.com/rails/ActionView/Helpers/AssetTagHelper/javascript_src_tag
