### PR TITLE
Fixed finding assets for absolute paths

### DIFF
--- a/lib/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf_helper.rb
@@ -65,7 +65,7 @@ module WickedPdfHelper
     URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
 
     def asset_pathname(source)
-      if Rails.configuration.assets.compile == false
+      if Rails.configuration.assets.compile == false || source.to_s[0] == '/'
         if asset_path(source) =~ URI_REGEXP
           # asset_path returns an absolute URL using asset_host if asset_host is set
           asset_path(source)
@@ -78,7 +78,7 @@ module WickedPdfHelper
     end
 
     def read_asset(source)
-      if Rails.configuration.assets.compile == false
+      if Rails.configuration.assets.compile == false || source.to_s[0] == '/'
         if asset_path(source) =~ URI_REGEXP
           require 'open-uri'
           asset = open(asset_pathname(source), 'r:UTF-8') {|f| f.read }


### PR DESCRIPTION
I use asset pipeline, but it happens i use absolute path for my assets. 
For example i have image located at app/public/some-image.png. I can use image_tag image_tag("/some-image.png"), but when i use wicked_pdf_image_tag("/some-image.png") in development mode(Rails.configuration.assets.compile == false) exception is raised: undefined method `pathname' for nil:NilClass.

This commit fix that (wicked_pdf_image_tag and other wicked_pdf_*_tag helpers).
