### PR TITLE
Set Protocol when asset_path(source) starts with // 

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -71,10 +71,10 @@ module WickedPdfHelper
     URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
 
     def asset_pathname(source)
-      if Rails.configuration.assets.compile == false || source.to_s[0] == '/'
-        if asset_path(source) =~ URI_REGEXP
+      if precompiled_asset?(source)
+        if (pathname = set_protocol(asset_path(source))) =~ URI_REGEXP
           # asset_path returns an absolute URL using asset_host if asset_host is set
-          asset_path(source)
+          pathname
         else
           File.join(Rails.public_path, asset_path(source).sub(/\A#{Rails.application.config.action_controller.relative_url_root}/, ''))
         end
@@ -83,9 +83,20 @@ module WickedPdfHelper
       end
     end
 
+    #will prepend a http or default_protocol to a protocol realtive URL
+    def set_protocol(source)
+      protocol = WickedPdf.config[:default_protocol] || "http"
+      source = [protocol, ":", source].join if source[0,2] == "//"
+      return source
+    end
+
+    def precompiled_asset?(source)
+      Rails.configuration.assets.compile == false || source.to_s[0] == '/'
+    end
+
     def read_asset(source)
-      if Rails.configuration.assets.compile == false || source.to_s[0] == '/'
-        if asset_path(source) =~ URI_REGEXP
+      if precompiled_asset?(source) 
+        if set_protocol(asset_path(source)) =~ URI_REGEXP
           read_from_uri(source)
         else
           IO.read(asset_pathname(source))

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -10,6 +10,20 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       expects(:asset_pathname => 'http://assets.domain.com/dummy.png')
       assert_equal 'http://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')
     end
+
+    test 'wicked_pdf_asset_path should return an url with a protocol when assets are served by an asset server with relative urls' do
+      expects(:asset_path => '//assets.domain.com/dummy.png')
+      expects("precompiled_asset?" => true)
+      assert_equal 'http://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')
+    end
+
+    test 'wicked_pdf_asset_path should return a path when assets are precompiled' do
+      expects("precompiled_asset?" => false)
+      path = wicked_pdf_asset_path('application.css')
+
+      assert path.include?("/assets/stylesheets/application.css")
+      assert path.include?("file://")
+    end
   end
 
 end


### PR DESCRIPTION
Check to see if a calculated asset path begins with // if it does concatenate http: to the front or w/e default protocol the dev desires.  

I did a minor refactor that let me test it easier (not too familiar with minitest) but abstracted the check for rails asset compilation or an absolute path to a function.  

The purpose of this is to allow action_controller.asset_host to be a protocol relative url and wicked_pdf will just work. 
