### PR TITLE
Add ability to pass HTML or Pathname to :cover option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class ThingsController < ApplicationController
                :basic_auth                     => false                         # when true username & password are automatically sent from session
                :username                       => 'TEXT',
                :password                       => 'TEXT',
-               :cover                          => 'URL',
+               :cover                          => 'URL, Pathname, or raw HTML string',
                :dpi                            => 'dpi',
                :encoding                       => 'TEXT',
                :user_style_sheet               => 'URL',

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -116,6 +116,7 @@ class WickedPdf
         parse_header_footer(:header => options.delete(:header),
                             :footer => options.delete(:footer),
                             :layout => options[:layout]),
+        parse_cover(options.delete(:cover)),
         parse_toc(options.delete(:toc)),
         parse_outline(options.delete(:outline)),
         parse_margins(options.delete(:margin)),
@@ -178,6 +179,22 @@ class WickedPdf
       r
     end
 
+    def parse_cover(argument)
+      arg = argument.to_s
+      return '' if arg.blank?
+      r = '--cover '
+      # Filesystem path or URL - hand off to wkhtmltopdf
+      if arg.include?(Rails.root.to_s) || (arg[0,4] == 'http')
+        r + arg
+      else # HTML content
+        @hf_tempfiles ||= []
+        @hf_tempfiles << tf=WickedPdfTempfile.new("wicked_cover_pdf.html")
+        tf.write arg
+        tf.flush
+        r + tf.path
+      end
+    end
+
     def parse_toc(options)
       r = '--toc ' unless options.nil?
       unless options.blank?
@@ -225,7 +242,6 @@ class WickedPdf
                                     :proxy,
                                     :username,
                                     :password,
-                                    :cover,
                                     :dpi,
                                     :encoding,
                                     :user_style_sheet])

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -129,10 +129,18 @@ class WickedPdfTest < ActiveSupport::TestCase
     end
   end
 
+  test "should parse cover" do
+    wp = WickedPdf.new
+    pathname = Rails.root.join('app','views','pdf','file.html')
+    assert_equal '--cover http://example.org', wp.get_parsed_options(:cover => 'http://example.org').strip, 'URL'
+    assert_equal "--cover #{pathname.to_s}", wp.get_parsed_options(:cover => pathname).strip, 'Pathname in Rails.root'
+    assert_match /--cover .+wicked_cover_pdf.+\.html/, wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
+  end
+
   test "should parse other options" do
     wp = WickedPdf.new
 
-    [ :orientation, :page_size, :proxy, :username, :password, :cover, :dpi,
+    [ :orientation, :page_size, :proxy, :username, :password, :dpi,
       :encoding, :user_style_sheet
     ].each do |o|
       assert_equal "--#{o.to_s.gsub('_', '-')} \"opts\"", wp.get_parsed_options(o => "opts").strip


### PR DESCRIPTION
`wkhtmltopdf` accepts a "cover" option that you can pass in a URL or
html file into.

This change allows the `:cover` option to be specified in any of the
following ways:

```
cover: 'http://example.org'

cover: Rails.root.join('public', 'pdf', 'pdf_cover.html')

cover: 'I AM COVERED'

cover: '<html><head><body>I AM COVERED IN HTML</body></html>'

cover: render_to_string('reports/cover.pdf.erb')
```
