### PR TITLE
Correctly replace headers in middleware

### DIFF
--- a/lib/wicked_pdf/middleware.rb
+++ b/lib/wicked_pdf/middleware.rb
@@ -81,8 +81,7 @@ class WickedPdf
 
     def set_request_to_render_as_pdf(env)
       @render_pdf = true
-      path = @request.path.sub(%r{\.pdf$}, '')
-      %w[PATH_INFO REQUEST_URI].each { |e| env[e] = path }
+      %w[PATH_INFO REQUEST_URI].each { |e| env[e] = env[e].sub(%r{\.pdf\b}, '') }
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
       env["Rack-Middleware-WickedPdf"] = "true"
     end


### PR DESCRIPTION
`PATH_INFO` and `REQUEST_URI` don't always match each other, and they don't always match `@request.path`. This is especially true if the app is mounted in a subdirectory in Apache. In that case (assuming the app is mounted at `/foo/bar` and the request is for `/foo/bar/baz.pdf?quux=1`:
-  `REQUEST_URI` will be something like `/foo/bar/baz.pdf?quux=1`
- `PATH_INFO` will be something like `/baz.pdf`
- `@request.path` will be something like `/foo/bar/baz.pdf`

This pull request changes the middleware to replace the `.pdf` extension in headers with themselves instead of with `@request.path`. I didn't see any tests for the middleware, so I haven't added any.
