### PR TITLE
Move outline options to support version 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ class ThingsController < ApplicationController
                :disable_smart_shrinking        => true,
                :use_xserver                    => true,
                :no_background                  => true,
-               :viewport_size                  => 'TEXT'                    # available only with use_xserver or patched QT
-               :extra                          => ''                        # directly inserted into the command to wkhtmltopdf
+               :viewport_size                  => 'TEXT',                    # available only with use_xserver or patched QT
+               :extra                          => '',                        # directly inserted into the command to wkhtmltopdf
+               :outline => {:outline           => true,
+                            :outline_depth     => LEVEL},
                :margin => {:top                => SIZE,                     # default 10 (mm)
                            :bottom             => SIZE,
                            :left               => SIZE,
@@ -199,9 +201,7 @@ class ThingsController < ApplicationController
                            :disable_links      => true,
                            :disable_toc_links  => true,
                            :disable_back_links => true,
-                           :xsl_style_sheet    => 'file.xsl'}, # optional XSLT stylesheet to use for styling table of contents
-               :outline => {:outline           => true,
-                            :outline_depth     => LEVEL}
+                           :xsl_style_sheet    => 'file.xsl'} # optional XSLT stylesheet to use for styling table of contents
       end
     end
   end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -124,13 +124,13 @@ class WickedPdf
   def parse_options(options)
     [
       parse_extra(options),
+      parse_outline(options.delete(:outline)),
       parse_header_footer(:header => options.delete(:header),
                           :footer => options.delete(:footer),
                           :layout => options[:layout]),
       parse_margins(options.delete(:margin)),
       parse_cover(options.delete(:cover)),
       parse_toc(options.delete(:toc)),
-      parse_outline(options.delete(:outline)),
       parse_others(options),
       parse_basic_auth(options)
     ].flatten


### PR DESCRIPTION
- Move outline option processing before header/footer processing.
