### PR TITLE
Fixed options[:temp_path] being deleted

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -45,8 +45,6 @@ class WickedPdf
   end
 
   def pdf_from_html_file(filepath, options = {})
-    # temp_path = options.delete(:temp_path)
-    # generated_pdf_file = WickedPdfTempfile.new('wicked_pdf_generated_file.pdf', temp_path)
     generated_pdf_file = WickedPdfTempfile.new("wicked_pdf_generated_file.pdf", options[:temp_path])
     command = [@exe_path]
     command << '-q' unless on_windows? # suppress errors on stdout
@@ -74,8 +72,6 @@ class WickedPdf
   end
 
   def pdf_from_string(string, options = {})
-    # temp_path = options.delete(:temp_path)
-    # string_file = WickedPdfTempfile.new('wicked_pdf.html', temp_path)
     string_file = WickedPdfTempfile.new("wicked_pdf.html", options[:temp_path])
     string_file.binmode
     string_file.write(string)


### PR DESCRIPTION
In my project, we need to use a special writable partition and cannot use /tmp for writing. However, due to this statement inside pdf_from_html_file() and pdf_from_string():

temp_path = options.delete(:temp_path)

options[:temp_path] is dropped in pdf_from_string(). When options are passed from pdf_from_string() to pdf_from_html_file(), there is no more options[:temp_path]. So /tmp is always used in pdf_from_html_file().

This PR fixed options[:temp_path] being deleted. So custom path other than /tmp can be used  in pdf_from_string() and pdf_from_html_file().
