### PR TITLE
Include path configuration for wkhtmltopdf-binary gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ gem 'wkhtmltopdf-binary'
 
 To your Gemfile and run `bundle install`.
 
-If your wkhtmltopdf executable is not on your webserver's path, you can configure it in an initializer:
+Then configure it to look in the initializer:
 
 ```ruby
 WickedPdf.config = {
-  :exe_path => '/usr/local/bin/wkhtmltopdf'
+  # wkhtmltopdf script will automatically determine the correct verson of the binary to use: It Just Works TM
+  exe_path: "#{ENV['GEM_HOME']}/gems/wkhtmltopdf-binary-#{Gem.loaded_specs['wkhtmltopdf-binary'].version}/bin/wkhtmltopdf"
 }
 ```
+
+
 
 For more information about `wkhtmltopdf`, see the project's [homepage](http://wkhtmltopdf.org/).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ gem 'wkhtmltopdf-binary'
 
 To your Gemfile and run `bundle install`.
 
-Then configure it to look in the initializer:
+Then configure the wicked_pdf initializer to look in the wkhtmltopdf-binary path:
 
 ```ruby
 WickedPdf.config = {


### PR DESCRIPTION
Just spent a good hour trying to find this solution.  Most of the options I saw gave the instruction "put in the right path".  I figured there was a way to grab the 'right path', but wasn't quite well versed to figure it out.  I almost gave up trying to figure it out and went the route of downloading the binary, then extracting it, and putting it into my /bin.  Not very future proof.

 This will automatically update the path when the gem is updated, and the script it points to works by looking at the system to determine the correct binary.  Much cleaner.

Hope it helps!