### PR TITLE
fix README #render_to_string usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ WickedPdf.new.pdf_from_string(
 )
 
 # or from your controller, using views & templates and all wicked_pdf options as normal
-pdf = render_to_string :template => "templates/pdf.html.erb", :pdf => "some_file_name", encoding: "UTF-8"
+pdf = render_to_string :pdf => "some_file_name", :template => "templates/pdf.html.erb", :encoding => "UTF-8"
 
 # then save to a file
 save_path = Rails.root.join('pdfs','filename.pdf')


### PR DESCRIPTION
I found that value of :pdf key doesn't use in #render_to_string as README says. So I just change README with properly passed attributes. 
