### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ However, the wicked_pdf_* helpers will use file:/// paths for assets when using 
 ```html
     <%= params[:debug].present? ? image_tag('foo') : wicked_pdf_image_tag('foo') %>
 ```
+
+#### Gotchas
+
+If one image from your HTML cannot be found (relative or wrong path for ie), others images with right paths **may not** be displayed in the output PDF as well (it seems to be an issue with wkhtmltopdf).
+
 ### Inspiration
 
 You may have noticed: this plugin is heavily inspired by the PrinceXML plugin [princely](http://github.com/mbleigh/princely/tree/master).  PrinceXML's cost was prohibitive for me. So, with a little help from some friends (thanks [jqr](http://github.com/jqr)), I tracked down wkhtmltopdf, and here we are.


### PR DESCRIPTION
Writing about an issue I had not only with this gem but also with pdfkit, It seems to be an issue from wkhtmltopdf.

You can reproduce it by yourselves.

```ruby
pdf = WickedPdf.new.pdf_from_string('<h1>Hello There!</h1><img src="../img/spsp.gif"/><img src="http://rubyonrails.org/images/pages/overview/screencasts2.png"/><img src="..dwadwadaw/dwad.png"/>')

save_path = Rails.root.join('tmp','filename.pdf')
File.open(save_path, 'wb') do |file|
  file << pdf
end
```