### PR TITLE
recommend official downloads page for wkhtmltopdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,7 @@ Mime::Type.register "application/pdf", :pdf
 ```
 to `config/initializers/mime_types.rb` in older versions of Rails.
 
-Because `wicked_pdf` is a wrapper for  [wkhtmltopdf](http://wkhtmltopdf.org/), you'll need to install that, too.
-
-The simplest way to install all of the binaries (Linux, OSX, Windows) is through the gem [wkhtmltopdf-binary](https://github.com/steerio/wkhtmltopdf-binary).
-To install that, add a second gem
-
-```ruby
-gem 'wkhtmltopdf-binary'
-```
-
-To your Gemfile and run `bundle install`.
+Because `wicked_pdf` is a wrapper for [wkhtmltopdf](http://wkhtmltopdf.org/), you'll need to download and install the appropriate package from their [download page](http://wkhtmltopdf.org/downloads.html#stable).
 
 If your wkhtmltopdf executable is not on your webserver's path, you can configure it in an initializer:
 


### PR DESCRIPTION
The wkhtmltopdf-binary gem provides a very outdated version, while packages for almost all platforms are available from the official downloads page.
