### PR TITLE
Fix parsed options order

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -126,14 +126,14 @@ class WickedPdf
   def parse_options(options)
     [
       parse_extra(options),
+      parse_others(options),
       parse_global(options),
       parse_outline(options.delete(:outline)),
-      parse_cover(options.delete(:cover)),
-      parse_toc(options.delete(:toc)),
       parse_header_footer(:header => options.delete(:header),
                           :footer => options.delete(:footer),
                           :layout => options[:layout]),
-      parse_others(options),
+      parse_cover(options.delete(:cover)),
+      parse_toc(options.delete(:toc)),
       parse_basic_auth(options)
     ].flatten
   end

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -225,4 +225,10 @@ class WickedPdfTest < ActiveSupport::TestCase
       assert_equal @wp.get_valid_option(name), "--#{name}"
     end
   end
+
+  test '-- options should not be given after object' do
+    options = {header: {center: 3}, cover: 'http://example.org', disable_javascript: true}
+    cover_option = @wp.get_valid_option('cover')
+    assert_equal @wp.get_parsed_options(options), "--disable-javascript --header-center 3 #{cover_option} http://example.org"
+  end
 end


### PR DESCRIPTION
If options with a `--` prefix are given to `wkhtmltopdf` after an
object, they are swallowed. For instance, if a cover object and some
footer options are given, the footer will not be displayed.

This commits fixes this behavior by changing the order of the parsed
options.