### PR TITLE
Fix bin path detection logic

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -327,7 +327,8 @@ class WickedPdf
     possible_locations = (ENV['PATH'].split(':') + %w(/usr/bin /usr/local/bin ~/bin)).uniq
     exe_path ||= WickedPdf.config[:exe_path] unless WickedPdf.config.empty?
     exe_path ||= begin
-      (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
+      detected_path = (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
+      detected_path.present? && detected_path
     rescue
       nil
     end


### PR DESCRIPTION
`bundle exec which wkhtmltopdf` or `which wkhtmltopdf` should return empty
strings if nothing is found. Since an empty string is truthy, it'll prevent
`possible_locations` lookups from happening.

The fix is to make sure that a blank `which` will be converted to
something falsy.