### PR TITLE
Add WickedPdf#pdf_from_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ pdf = WickedPdf.new.pdf_from_string('<h1>Hello There!</h1>')
 # Path must be absolute path
 pdf = WickedPdf.new.pdf_from_html_file('/your/absolute/path/here')
 
+# create a pdf from a URL
+pdf = WickedPdf.new.pdf_from_url('https://github.com/mileszs/wicked_pdf')
+
 # create a pdf from string using templates, layouts and content option for header or footer
 WickedPdf.new.pdf_from_string(
   render_to_string('templates/pdf.html.erb', layout: 'pdfs/layout_pdf'),


### PR DESCRIPTION
Resolves issue #416 by adding `WickedPdf#pdf_from_url`. A fairly simple change. `pdf_from_html_file` is now just a special case of `pdf_from_url` with a URL scheme of `file://`.