### PR TITLE
Remove rails dependency

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This is a big speed bump for people who want to use wicked_pdf in a simple Ruby script.  For instance, now I need to install libxml2 because rails depends on nokogiri which depends on libxml2.

Since anyone who wants to use wicked_pdf in a Rails app will, by definition, already have rails loaded, it would seem there's no need to require it in the gemspec.  Confirm/deny?