### PR TITLE
call to_s on file name for backwards compatibility

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -6,7 +6,7 @@ module WickedPdfHelper
   end
 
   def self.add_extension(filename, extension)
-    (filename.split(".").include?(extension) ? filename : "#{filename}.#{extension}")
+    (filename.to_s.split(".").include?(extension) ? filename : "#{filename}.#{extension}")
   end
 
   def wicked_pdf_stylesheet_link_tag(*sources)


### PR DESCRIPTION
Call to_s for people who might pass symbols/objects through as filenames.

The behavior got slightly changed in this merge:
https://github.com/mileszs/wicked_pdf/commit/656dd1591753d55db37bc446c8f231be9377b10a