### PR TITLE
Fix bug parsing asset paths out of CSS

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -34,7 +34,7 @@ module WickedPdfHelper
   end
 
   module Assets
-    ASSET_URL_REGEX = /url\(['"](.+)['"]\)(.+)/
+    ASSET_URL_REGEX = /url\(['"]([^'"]+)['"]\)(.+)/
 
     def wicked_pdf_stylesheet_link_tag(*sources)
       stylesheet_contents = sources.collect do |source|


### PR DESCRIPTION
Fixes a bug where assets are sometimes parsed incorrectly from CSS files. Mentioned in #375.