### PR TITLE
keep content because generate a pdf with footer content at second tim…

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -205,7 +205,6 @@ class WickedPdf
           @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
           tf.write options[hf][:content]
           tf.flush
-          options[hf].delete(:content)
           options[hf][:html] = {}
           options[hf][:html][:url] = "file:///#{tf.path}"
         end


### PR DESCRIPTION
keep content because generate a pdf with footer content at second time can not find footer tempfile

```ruby
WickedPdf.new.pdf_from_string(html, :page_size => "Letter", :disable_smart_shrinking => true, :footer => {:content => ERB.new(pdf_template).result(binding) } )
```
When above code run at 1st time. PDF generate successfully.
At 2nd time, it failed and raise ```QPaintDevice: Cannot destroy paint device that is being painted```
When I debugged. I found when 2nd time run above code. the command still using last time's options.
``` {footer: {html: {url: "/var/folders/****.html"} } } ``` But this file has been deleted.
So, I think keep  footer's content is easiest way to resolve this issue.
