### PR TITLE
Uses a duplicate options hash when parsing options

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -49,6 +49,7 @@ class WickedPdf
   end
 
   def pdf_from_string(string, options = {})
+    options = options.dup
     # merge in global config options
     options.merge!(WickedPdf.config) {|key, option, config| option}
     string_file = WickedPdfTempfile.new("wicked_pdf.html", options[:temp_path])


### PR DESCRIPTION
This will resolve #441.

The issue was that that parts of the options hash in memory was being deleted which wicked_pdf parsed the options, specifically in my case, the [margins hash](https://github.com/mileszs/wicked_pdf/blob/be360d648388c48534263d7d3c7208ca43e58db8/lib/wicked_pdf.rb#L295). This resulted in those options going away for subsequent pdf generations after Rails initialization. This was specifically an issue when using the wicked_pdf middleware because the options are passed in once at initialization. Instead of deleting the in memory options, I'm making a duplicate of it and using that. I tested it on a local application and it resolved my issues.