### PR TITLE
README Update: Replace the deprecated unescape() in the Page Numbering example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A bit of javascript can help you number your pages. Create a template or header/
       function number_pages() {
         var vars={};
         var x=document.location.search.substring(1).split('&');
-        for(var i in x) {var z=x[i].split('=',2);vars[z[0]] = unescape(z[1]);}
+        for(var i in x) {var z=x[i].split('=',2);vars[z[0]] = decodeURIComponent(z[1]);}
         var x=['frompage','topage','page','webpage','section','subsection','subsubsection'];
         for(var i in x) {
           var y = document.getElementsByClassName(x[i]);


### PR DESCRIPTION
I updated the Page Numbering example to use decodeURIComponent() instead of the deprecated unescape().