### PR TITLE
Asset URL fixes

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -3,12 +3,16 @@ require 'wicked_pdf/wicked_pdf_helper'
 
 if defined?(Rails)
 
-  if Rails::VERSION::MAJOR == 4
+  if Rails::VERSION::MAJOR == 3
 
     class WickedRailtie < Rails::Railtie
       initializer 'wicked_pdf.register' do |app|
         ActionController::Base.send :include, PdfHelper
-        ActionView::Base.send :include, WickedPdfHelper::Assets
+        if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
+          ActionView::Base.send :include, WickedPdfHelper::Assets
+        else
+          ActionView::Base.send :include, WickedPdfHelper
+        end
       end
     end
 
@@ -26,11 +30,7 @@ if defined?(Rails)
     class WickedRailtie < Rails::Railtie
       initializer 'wicked_pdf.register' do |app|
         ActionController::Base.send :include, PdfHelper
-        if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
-          ActionView::Base.send :include, WickedPdfHelper::Assets
-        else
-          ActionView::Base.send :include, WickedPdfHelper
-        end
+        ActionView::Base.send :include, WickedPdfHelper::Assets
       end
     end
 

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -34,7 +34,7 @@ module WickedPdfHelper
   end
 
   module Assets
-    ASSET_URL_REGEX = /url\(['"]?([^'"]+)['"]?\)(.+)/
+    ASSET_URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/
 
     def wicked_pdf_stylesheet_link_tag(*sources)
       stylesheet_contents = sources.collect do |source|
@@ -43,7 +43,7 @@ module WickedPdfHelper
       end.join("\n")
 
       stylesheet_contents.gsub(ASSET_URL_REGEX) do
-        "url(#{wicked_pdf_asset_path($1)})#{$2}"
+        "url(#{wicked_pdf_asset_path(Regexp.last_match[1])})"
       end.html_safe
     end
 

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -95,7 +95,7 @@ module WickedPdfHelper
       protocol = WickedPdf.config[:default_protocol] || 'http'
       if source[0, 2] == '//'
         source = [protocol, ':', source].join
-      elsif !source[0, 8].include?('://')
+      elsif source[0] != '/' && !source[0, 8].include?('://')
         source = [protocol, '://', source].join
       end
       source

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -34,7 +34,7 @@ module WickedPdfHelper
   end
 
   module Assets
-    ASSET_URL_REGEX = /url\(['"]([^'"]+)['"]\)(.+)/
+    ASSET_URL_REGEX = /url\(['"]?([^'"]+)['"]?\)(.+)/
 
     def wicked_pdf_stylesheet_link_tag(*sources)
       stylesheet_contents = sources.collect do |source|

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -5,7 +5,7 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
 
   include WickedPdfHelper::Assets
 
-  if Rails::VERSION::MAJOR == 4
+  if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
     test 'wicked_pdf_asset_path should return a url when assets are served by an asset server' do
       expects(:asset_pathname => 'http://assets.domain.com/dummy.png')
       assert_equal 'http://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -35,6 +35,15 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       assert path.include?('/assets/stylesheets/application.css')
       assert path.include?('file:///')
     end
-  end
 
+    test 'WickedPdfHelper::Assets::ASSET_URL_REGEX should match various URL data type formats' do
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'/asset/stylesheets/application.css\');'
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("/asset/stylesheets/application.css");'
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(/asset/stylesheets/application.css);'
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'http://assets.domain.com/dummy.png\');'
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("http://assets.domain.com/dummy.png");'
+      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(http://assets.domain.com/dummy.png);'
+      assert_no_match WickedPdfHelper::Assets::ASSET_URL_REGEX, '.url { \'http://assets.domain.com/dummy.png\' }'
+    end
+  end
 end

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -45,5 +45,12 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(http://assets.domain.com/dummy.png);'
       assert_no_match WickedPdfHelper::Assets::ASSET_URL_REGEX, '.url { \'http://assets.domain.com/dummy.png\' }'
     end
+
+    test 'set_protocol should properly set the protocol when the asset is precompiled' do
+      assert_equal 'http://assets.domain.com/dummy.png', set_protocol('//assets.domain.com/dummy.png')
+      assert_equal '/assets.domain.com/dummy.png', set_protocol('/assets.domain.com/dummy.png')
+      assert_equal 'http://assets.domain.com/dummy.png', set_protocol('http://assets.domain.com/dummy.png')
+      assert_equal 'https://assets.domain.com/dummy.png', set_protocol('https://assets.domain.com/dummy.png')
+    end
   end
 end


### PR DESCRIPTION
1. Fixed some handling for relative asset URLs getting protocols stuck onto them
2. Fixed detection of asset URLs that weren't surrounded by quotes
3. Expanded the AssetsTest and Railtie logic for more versions of Rails. If this is controversial I can split it into a new pull request.