### PR TITLE
Adding missing background flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ class ThingsController < ApplicationController
                print_media_type:               true,
                disable_smart_shrinking:        true,
                use_xserver:                    true,
+               background:                     false,                     # backround needs to be true to enable background colors to render
                no_background:                  true,
                viewport_size:                  'TEXT',                    # available only with use_xserver or patched QT
                extra:                          '',                        # directly inserted into the command to wkhtmltopdf


### PR DESCRIPTION
The no_background flag was documented, but no reference was made to the `background` flag.  To enable background-color in pdfs setting no_background to false does not work.  This seems a little illogical. So I hope this helps