### PR TITLE
Changes for Rubocop + Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language:
   - ruby
 bundler_args: --verbose
+sudo: required
 rvm:
   - 1.9.2
   - 1.9.3
   - 2.0
   - 2.1
   - 2.2
+  - ruby-head
 gemfile:
   - gemfiles/3.0.gemfile
   - gemfiles/3.1.gemfile
@@ -52,3 +54,4 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.2.0
       gemfile: gemfiles/rails_edge.gemfile
+    - rvm: ruby-head

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -164,11 +164,11 @@ class WickedPdf
     end
     if type == :name_value
       parts = value.to_s.split(' ')
-      ["--#{name.gsub('_', '-')}", *parts]
+      ["--#{name.tr('_', '-')}", *parts]
     elsif type == :boolean
-      ["--#{name.gsub('_', '-')}"]
+      ["--#{name.tr('_', '-')}"]
     else
-      ["--#{name.gsub('_', '-')}", value.to_s]
+      ["--#{name.tr('_', '-')}", value.to_s]
     end
   end
 

--- a/lib/wicked_pdf/middleware.rb
+++ b/lib/wicked_pdf/middleware.rb
@@ -1,13 +1,13 @@
 class WickedPdf
   class Middleware
     def initialize(app, options = {}, conditions = {})
-      @app        = app
-      @options    = (WickedPdf.config || {}).merge(options)
+      @app = app
+      @options = (WickedPdf.config || {}).merge(options)
       @conditions = conditions
     end
 
     def call(env)
-      @request    = Rack::Request.new(env)
+      @request = Rack::Request.new(env)
       @render_pdf = false
 
       set_request_to_render_as_pdf(env) if render_as_pdf?
@@ -25,10 +25,10 @@ class WickedPdf
         headers.delete('ETag')
         headers.delete('Cache-Control')
 
-        headers['Content-Length']         = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
-        headers['Content-Type']           = 'application/pdf'
+        headers['Content-Length'] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
+        headers['Content-Type'] = 'application/pdf'
         if @options.fetch(:disposition, '') == 'attachment'
-          headers['Content-Disposition']       = 'attachment'
+          headers['Content-Disposition'] = 'attachment'
           headers['Content-Transfer-Encoding'] = 'binary'
         end
       end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -53,7 +53,12 @@ module PdfHelper
   end
 
   def make_pdf(options = {})
-    render_opts = { :template => options[:template], :layout => options[:layout], :formats => options[:formats], :handlers => options[:handlers] }
+    render_opts = {
+      :template => options[:template],
+      :layout => options[:layout],
+      :formats => options[:formats],
+      :handlers => options[:handlers]
+    }
     render_opts.merge!(:locals => options[:locals]) if options[:locals]
     render_opts.merge!(:file => options[:file]) if options[:file]
     html_string = render_to_string(render_opts)
@@ -68,7 +73,13 @@ module PdfHelper
     options[:template] ||= File.join(controller_path, action_name)
     options[:disposition] ||= 'inline'
     if options[:show_as_html]
-      render_opts = { :template => options[:template], :layout => options[:layout], :formats => options[:formats], :handlers => options[:handlers], :content_type => 'text/html' }
+      render_opts = {
+        :template => options[:template],
+        :layout => options[:layout],
+        :formats => options[:formats],
+        :handlers => options[:handlers],
+        :content_type => 'text/html'
+      }
       render_opts.merge!(:locals => options[:locals]) if options[:locals]
       render_opts.merge!(:file => options[:file]) if options[:file]
       render(render_opts)
@@ -87,7 +98,12 @@ module PdfHelper
       @hf_tempfiles = [] unless defined?(@hf_tempfiles)
       @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
       options[hf][:html][:layout] ||= options[:layout]
-      render_opts = { :template => options[hf][:html][:template], :layout => options[hf][:html][:layout], :formats => options[hf][:html][:formats], :handlers => options[hf][:html][:handlers] }
+      render_opts = {
+        :template => options[hf][:html][:template],
+        :layout => options[hf][:html][:layout],
+        :formats => options[hf][:html][:formats],
+        :handlers => options[hf][:html][:handlers]
+      }
       render_opts.merge!(:locals => options[hf][:html][:locals]) if options[hf][:html][:locals]
       render_opts.merge!(:file => options[hf][:html][:file]) if options[:file]
       tf.write render_to_string(render_opts)

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -22,9 +22,7 @@ module WickedPdfHelper
           "url(#{Regexp.last_match[1]})"
         else
           asset = Regexp.last_match[1]
-          if asset_exists?(asset)
-            "url(#{wicked_pdf_asset_path(asset)})"
-          end
+          "url(#{wicked_pdf_asset_path(asset)})" if asset_exists?(asset)
         end
       end.html_safe
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 
-require File.expand_path('../dummy/config/environment.rb',  __FILE__)
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
 
 require 'test/unit'
 require 'mocha'

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -95,12 +95,12 @@ class WickedPdfTest < ActiveSupport::TestCase
 
     [:header, :footer].each do |hf|
       [:center, :font_name, :left, :right].each do |o|
-        assert_equal "--#{hf}-#{o.to_s.gsub('_', '-')} header_footer",
+        assert_equal "--#{hf}-#{o.to_s.tr('_', '-')} header_footer",
                      wp.get_parsed_options(hf => { o => 'header_footer' }).strip
       end
 
       [:font_size, :spacing].each do |o|
-        assert_equal "--#{hf}-#{o.to_s.gsub('_', '-')} 12",
+        assert_equal "--#{hf}-#{o.to_s.tr('_', '-')} 12",
                      wp.get_parsed_options(hf => { o => '12' }).strip
       end
 
@@ -116,7 +116,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     toc_option = wp.get_valid_option('toc')
 
     [:font_name, :header_text].each do |o|
-      assert_equal "#{toc_option} --toc-#{o.to_s.gsub('_', '-')} toc",
+      assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')} toc",
                    wp.get_parsed_options(:toc => { o => 'toc' }).strip
     end
 
@@ -125,12 +125,12 @@ class WickedPdfTest < ActiveSupport::TestCase
       :l5_font_size, :l6_font_size, :l7_font_size, :l1_indentation, :l2_indentation,
       :l3_indentation, :l4_indentation, :l5_indentation, :l6_indentation, :l7_indentation
     ].each do |o|
-      assert_equal "#{toc_option} --toc-#{o.to_s.gsub('_', '-')} 5",
+      assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')} 5",
                    wp.get_parsed_options(:toc => { o => 5 }).strip
     end
 
     [:no_dots, :disable_links, :disable_back_links].each do |o|
-      assert_equal "#{toc_option} --toc-#{o.to_s.gsub('_', '-')}",
+      assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')}",
                    wp.get_parsed_options(:toc => { o => true }).strip
     end
   end
@@ -167,18 +167,18 @@ class WickedPdfTest < ActiveSupport::TestCase
       :orientation, :page_size, :proxy, :username, :password, :dpi,
       :encoding, :user_style_sheet
     ].each do |o|
-      assert_equal "--#{o.to_s.gsub('_', '-')} opts", wp.get_parsed_options(o => 'opts').strip
+      assert_equal "--#{o.to_s.tr('_', '-')} opts", wp.get_parsed_options(o => 'opts').strip
     end
 
     [:cookie, :post].each do |o|
-      assert_equal "--#{o.to_s.gsub('_', '-')} name value", wp.get_parsed_options(o => 'name value').strip
+      assert_equal "--#{o.to_s.tr('_', '-')} name value", wp.get_parsed_options(o => 'name value').strip
 
-      nv_formatter = proc { |number| "--#{o.to_s.gsub('_', '-')} par#{number} val#{number}" }
+      nv_formatter = proc { |number| "--#{o.to_s.tr('_', '-')} par#{number} val#{number}" }
       assert_equal "#{nv_formatter.call(1)} #{nv_formatter.call(2)}", wp.get_parsed_options(o => ['par1 val1', 'par2 val2']).strip
     end
 
     [:redirect_delay, :zoom, :page_offset].each do |o|
-      assert_equal "--#{o.to_s.gsub('_', '-')} 5", wp.get_parsed_options(o => 5).strip
+      assert_equal "--#{o.to_s.tr('_', '-')} 5", wp.get_parsed_options(o => 5).strip
     end
 
     [
@@ -186,7 +186,7 @@ class WickedPdfTest < ActiveSupport::TestCase
       :enable_plugins, :disable_internal_links, :disable_external_links,
       :print_media_type, :disable_smart_shrinking, :use_xserver, :no_background
     ].each do |o|
-      assert_equal "--#{o.to_s.gsub('_', '-')}", wp.get_parsed_options(o => true).strip
+      assert_equal "--#{o.to_s.tr('_', '-')}", wp.get_parsed_options(o => true).strip
     end
   end
 


### PR DESCRIPTION
## Changed
* Update Travis file to test against ruby-head + use new Travis containers (roughly halves time test time)
* Some whitespace refactoring to reduce line length & improve readability 
* Fix some Rubocop complaints (mainly switching from `.gsub` to `.tr`)