### PR TITLE
Embed JavaScript in Base64 encoded form

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -39,7 +39,7 @@ module WickedPdfHelper
     def wicked_pdf_javascript_include_tag(*sources)
       sources.collect do |source|
         source = WickedPdfHelper.add_extension(source, 'js')
-        "<script type='text/javascript'>#{read_asset(source)}</script>"
+        "<script type='text/javascript' src='#{wicked_pdf_asset_base64(source)}'></script>"
       end.join("\n").html_safe
     end
 


### PR DESCRIPTION
Embedding JavaScript directly in HTML using `<script>` tags can fail if the embedded JS contains certain character sequences.

This can be resolved by encoding our JS as a Base64 string and then embedding it as a data URI.