### PR TITLE
Fix #476 issue - problem with sprockets 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language:
   - ruby
+before_install:
+  - sudo apt-get update -qq
+  - gem update bundler
 bundler_args: --verbose
 sudo: required
 rvm:
@@ -26,6 +29,7 @@ matrix:
   include:
     - rvm: 1.8.7
       before_install:
+        - sudo apt-get update -qq
         - gem update --system 1.8.25
         - gem --version
       gemfile: gemfiles/2.3.gemfile

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -18,28 +18,74 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
     end
 
     test 'wicked_pdf_asset_path should return a url when assets are served by an asset server using HTTPS' do
-      expects(:asset_path => 'https://assets.domain.com/dummy.png', 'precompiled_asset?' => true)
+      Rails.configuration.assets.expects(:compile => false)
+      expects(:asset_path => 'https://assets.domain.com/dummy.png')
       assert_equal 'https://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')
     end
 
     test 'wicked_pdf_asset_path should return a url with a protocol when assets are served by an asset server with relative urls' do
+      Rails.configuration.assets.expects(:compile => false)
       expects(:asset_path => '//assets.domain.com/dummy.png')
-      expects('precompiled_asset?' => true)
       assert_equal 'http://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')
     end
 
     test 'wicked_pdf_asset_path should return a url with a protocol when assets are served by an asset server with no protocol set' do
+      Rails.configuration.assets.expects(:compile => false)
       expects(:asset_path => 'assets.domain.com/dummy.png')
-      expects('precompiled_asset?' => true)
       assert_equal 'http://assets.domain.com/dummy.png', wicked_pdf_asset_path('dummy.png')
     end
 
-    test 'wicked_pdf_asset_path should return a path when assets are precompiled' do
-      expects('precompiled_asset?' => false)
+    test 'wicked_pdf_asset_path should return a path' do
+      Rails.configuration.assets.expects(:compile => true)
       path = wicked_pdf_asset_path('application.css')
 
-      assert path.include?('/assets/stylesheets/application.css')
+      assert path.include?('/app/assets/stylesheets/application.css')
       assert path.include?('file:///')
+
+      Rails.configuration.assets.expects(:compile => false)
+      expects(:asset_path => '/assets/application-6fba03f13d6ff1553477dba03475c4b9b02542e9fb8913bd63c258f4de5b48d9.css')
+      path = wicked_pdf_asset_path('application.css')
+
+      assert path.include?('/public/assets/application-6fba03f13d6ff1553477dba03475c4b9b02542e9fb8913bd63c258f4de5b48d9.css')
+      assert path.include?('file:///')
+    end
+
+    # This assets does not exists so probably it doesn't matter what is
+    # returned, but lets ensure that returned value is the same when assets
+    # are precompiled and when they are not
+    test 'wicked_pdf_asset_path should return a path when asset does not exist' do
+      Rails.configuration.assets.expects(:compile => true)
+      path = wicked_pdf_asset_path('missing.png')
+
+      assert path.include?('/public/missing.png')
+      assert path.include?('file:///')
+
+      Rails.configuration.assets.expects(:compile => false)
+      expects(:asset_path => '/missing.png')
+      path = wicked_pdf_asset_path('missing.png')
+
+      assert path.include?('/public/missing.png')
+      assert path.include?('file:///')
+    end
+
+    test 'wicked_pdf_asset_path should return a url when asset is url' do
+      Rails.configuration.assets.expects(:compile => true)
+      expects(:asset_path => 'http://example.com/rails.png')
+      assert_equal 'http://example.com/rails.png', wicked_pdf_asset_path('http://example.com/rails.png')
+
+      Rails.configuration.assets.expects(:compile => false)
+      expects(:asset_path => 'http://example.com/rails.png')
+      assert_equal 'http://example.com/rails.png', wicked_pdf_asset_path('http://example.com/rails.png')
+    end
+
+    test 'wicked_pdf_asset_path should return a url when asset is url without protocol' do
+      Rails.configuration.assets.expects(:compile => true)
+      expects(:asset_path => '//example.com/rails.png')
+      assert_equal 'http://example.com/rails.png', wicked_pdf_asset_path('//example.com/rails.png')
+
+      Rails.configuration.assets.expects(:compile => false)
+      expects(:asset_path => '//example.com/rails.png')
+      assert_equal 'http://example.com/rails.png', wicked_pdf_asset_path('//example.com/rails.png')
     end
 
     test 'WickedPdfHelper::Assets::ASSET_URL_REGEX should match various URL data type formats' do

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -6,9 +6,6 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
 
   if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
     test 'wicked_pdf_asset_base64 returns a base64 encoded asset' do
-      source = File.new('test/fixtures/wicked.css', 'r')
-      destination = Rails.root.join('app', 'assets', 'stylesheets', 'wicked.css')
-      File.open(destination, 'w') { |f| f.write(source) }
       assert_match /data:text\/css;base64,.+/, wicked_pdf_asset_base64('wicked.css')
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,9 @@ end
 require 'wicked_pdf'
 
 Rails.backtrace_cleaner.remove_silencers!
+
+if (assets_dir = Rails.root.join('app/assets')) && File.directory?(assets_dir)
+  destination = assets_dir.join('stylesheets/wicked.css')
+  source = File.read('test/fixtures/wicked.css')
+  File.open(destination, 'w') { |f| f.write(source) }
+end


### PR DESCRIPTION
Compatibility with sprockets 3.0 was broken by that PR https://github.com/mileszs/wicked_pdf/pull/464. That PR also broke something else - CSS content like this "url(http://example.com/rails.png)" was removed.

This PR fixes compatibility with sprockets 3.0, reverts changes from #464 (but fixes its issues), and fixes some others issues. I added few new tests.

---

There is still one issue not fixed. When assets digest is enabled and assets compilation is enabled (default rails development configuration) and we have css(scss) like this:

    img { image-url("rails.png"); }

this css is read as

    img { url("/assets/rails-6fba03f13d6ff1553477dba03475c4b9b02542e9fb8913bd63c258f4de5b48d9.png"); }
 
and later it is changed to

    img { url("file:////home/user/project/public/assets/rails-6fba03f13d6ff1553477dba03475c4b9b02542e9fb8913bd63c258f4de5b48d9.png"); }

but that file does not exists. I don't know how it can be handled. At least it works in production (when assets are precompilated).

---

I tried to describe all changes in commit description. I hope I didn't break anything.