### PR TITLE
No values arguments processing

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -324,8 +324,8 @@ class WickedPdf
                                   :print_media_type,
                                   :disable_smart_shrinking,
                                   :use_xserver,
-                                  :no_background], '', :boolean)
-      r += make_options(options, [:no_stop_slow_scripts], '', :boolean)
+                                  :no_background,
+                                  :no_stop_slow_scripts], '', :boolean)
     end
     r
   end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -166,7 +166,11 @@ class WickedPdf
       parts = value.to_s.split(' ')
       ["--#{name.tr('_', '-')}", *parts]
     elsif type == :boolean
-      ["--#{name.tr('_', '-')}"]
+      if value
+        ["--#{name.tr('_', '-')}"]
+      else
+        []
+      end
     else
       ["--#{name.tr('_', '-')}", value.to_s]
     end
@@ -321,7 +325,7 @@ class WickedPdf
                                   :disable_smart_shrinking,
                                   :use_xserver,
                                   :no_background], '', :boolean)
-      r += make_options(options, [:no_stop_slow_scripts], '', nil)
+      r += make_options(options, [:no_stop_slow_scripts], '', :boolean)
     end
     r
   end


### PR DESCRIPTION
Set `no_stop_slow_scripts` as `:boolean` for prevent its value passing (--no-stop-slow-scripts argument has no value)
If any `:boolean` option has `false` value, option not passes as command line argument (`make_option` method)