### PR TITLE
Removes circular require from lib/wicked_pdf/pdf_helper.rb

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,5 +1,4 @@
 module PdfHelper
-  require 'wicked_pdf'
   require 'tempfile'
 
   def self.included(base)


### PR DESCRIPTION
In Ruby 2.3.0:

```
lib/wicked_pdf/pdf_helper.rb:2: warning: loading in progress, circular require considered harmful
<spew>
```