### PR TITLE
Regex ambiquity

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,5 +1,4 @@
 module PdfHelper
-  require 'wicked_pdf'
   require 'tempfile'
 
   def self.included(base)

--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -21,7 +21,7 @@ class PdfHelperTest < ActionController::TestCase
     test 'should prerender header and footer :template options' do
       options = @ac.send(:prerender_header_and_footer,
                          :header => { :html => { :template => 'hf.html.erb' } })
-      assert_match /^file:\/\/\/.*wicked_header_pdf.*\.html/, options[:header][:html][:url]
+      assert_match %r(^file:\/\/\/.*wicked_header_pdf.*\.html), options[:header][:html][:url]
     end
   end
 end

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -6,7 +6,7 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
 
   if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
     test 'wicked_pdf_asset_base64 returns a base64 encoded asset' do
-      assert_match /data:text\/css;base64,.+/, wicked_pdf_asset_base64('wicked.css')
+      assert_match %r(data:text\/css;base64,.+), wicked_pdf_asset_base64('wicked.css')
     end
 
     test 'wicked_pdf_asset_path should return a url when assets are served by an asset server' do

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -157,7 +157,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     pathname = Rails.root.join('app', 'views', 'pdf', 'file.html')
     assert_equal "#{cover_option} http://example.org", wp.get_parsed_options(:cover => 'http://example.org').strip, 'URL'
     assert_equal "#{cover_option} #{pathname}", wp.get_parsed_options(:cover => pathname).strip, 'Pathname'
-    assert_match /#{cover_option} .+wicked_cover_pdf.+\.html/, wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
+    assert_match %r(#{cover_option} .+wicked_cover_pdf.+\.html), wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
   end
 
   test 'should parse other options' do

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.date          = Time.now.strftime('%Y-%m-%d')
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
On 2.3.0 (fairly stock):

```
warning: ambiguous first argument; put parentheses or a space even after `/' operator
```

Switched to `%r` for the offending regular expressions.