### PR TITLE
Test refactor

### DIFF
--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -26,26 +26,23 @@ class WickedPdfTest < ActiveSupport::TestCase
   end
 
   test 'should generate PDF from html document' do
-    wp = WickedPdf.new
-    pdf = wp.pdf_from_string HTML_DOCUMENT
+    pdf = @wp.pdf_from_string HTML_DOCUMENT
     assert pdf.start_with?('%PDF-1.4')
     assert pdf.rstrip.end_with?('%%EOF')
     assert pdf.length > 100
   end
 
   test 'should generate PDF from html document with long lines' do
-    wp = WickedPdf.new
     document_with_long_line_file = File.new('test/fixtures/document_with_long_line.html', 'r')
-    pdf = wp.pdf_from_string(document_with_long_line_file.read)
+    pdf = @wp.pdf_from_string(document_with_long_line_file.read)
     assert pdf.start_with?('%PDF-1.4')
     assert pdf.rstrip.end_with?('%%EOF')
     assert pdf.length > 100
   end
 
   test 'should generate PDF from html existing HTML file without converting it to string' do
-    wp = WickedPdf.new
     filepath = File.join(Dir.pwd, 'test/fixtures/document_with_long_line.html')
-    pdf = wp.pdf_from_html_file(filepath)
+    pdf = @wp.pdf_from_html_file(filepath)
     assert pdf.start_with?('%PDF-1.4')
     assert pdf.rstrip.end_with?('%%EOF')
     assert pdf.length > 100

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -88,33 +88,30 @@ class WickedPdfTest < ActiveSupport::TestCase
   end
 
   test 'should parse header and footer options' do
-    wp = WickedPdf.new
-
     [:header, :footer].each do |hf|
       [:center, :font_name, :left, :right].each do |o|
         assert_equal "--#{hf}-#{o.to_s.tr('_', '-')} header_footer",
-                     wp.get_parsed_options(hf => { o => 'header_footer' }).strip
+                     @wp.get_parsed_options(hf => { o => 'header_footer' }).strip
       end
 
       [:font_size, :spacing].each do |o|
         assert_equal "--#{hf}-#{o.to_s.tr('_', '-')} 12",
-                     wp.get_parsed_options(hf => { o => '12' }).strip
+                     @wp.get_parsed_options(hf => { o => '12' }).strip
       end
 
       assert_equal "--#{hf}-line",
-                   wp.get_parsed_options(hf => { :line => true }).strip
+                   @wp.get_parsed_options(hf => { :line => true }).strip
       assert_equal "--#{hf}-html http://www.abc.com",
-                   wp.get_parsed_options(hf => { :html => { :url => 'http://www.abc.com' } }).strip
+                   @wp.get_parsed_options(hf => { :html => { :url => 'http://www.abc.com' } }).strip
     end
   end
 
   test 'should parse toc options' do
-    wp = WickedPdf.new
-    toc_option = wp.get_valid_option('toc')
+    toc_option = @wp.get_valid_option('toc')
 
     [:font_name, :header_text].each do |o|
       assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')} toc",
-                   wp.get_parsed_options(:toc => { o => 'toc' }).strip
+                   @wp.get_parsed_options(:toc => { o => 'toc' }).strip
     end
 
     [
@@ -123,59 +120,52 @@ class WickedPdfTest < ActiveSupport::TestCase
       :l3_indentation, :l4_indentation, :l5_indentation, :l6_indentation, :l7_indentation
     ].each do |o|
       assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')} 5",
-                   wp.get_parsed_options(:toc => { o => 5 }).strip
+                   @wp.get_parsed_options(:toc => { o => 5 }).strip
     end
 
     [:no_dots, :disable_links, :disable_back_links].each do |o|
       assert_equal "#{toc_option} --toc-#{o.to_s.tr('_', '-')}",
-                   wp.get_parsed_options(:toc => { o => true }).strip
+                   @wp.get_parsed_options(:toc => { o => true }).strip
     end
   end
 
   test 'should parse outline options' do
-    wp = WickedPdf.new
-
-    assert_equal '--outline', wp.get_parsed_options(:outline => { :outline => true }).strip
-    assert_equal '--outline-depth 5', wp.get_parsed_options(:outline => { :outline_depth => 5 }).strip
+    assert_equal '--outline', @wp.get_parsed_options(:outline => { :outline => true }).strip
+    assert_equal '--outline-depth 5', @wp.get_parsed_options(:outline => { :outline_depth => 5 }).strip
   end
 
   test 'should parse margins options' do
-    wp = WickedPdf.new
-
     [:top, :bottom, :left, :right].each do |o|
-      assert_equal "--margin-#{o} 12", wp.get_parsed_options(:margin => { o => '12' }).strip
+      assert_equal "--margin-#{o} 12", @wp.get_parsed_options(:margin => { o => '12' }).strip
     end
   end
 
   test 'should parse cover' do
-    wp = WickedPdf.new
-    cover_option = wp.get_valid_option('cover')
+    cover_option = @wp.get_valid_option('cover')
 
     pathname = Rails.root.join('app', 'views', 'pdf', 'file.html')
-    assert_equal "#{cover_option} http://example.org", wp.get_parsed_options(:cover => 'http://example.org').strip, 'URL'
-    assert_equal "#{cover_option} #{pathname}", wp.get_parsed_options(:cover => pathname).strip, 'Pathname'
-    assert_match %r(#{cover_option} .+wicked_cover_pdf.+\.html), wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
+    assert_equal "#{cover_option} http://example.org", @wp.get_parsed_options(:cover => 'http://example.org').strip, 'URL'
+    assert_equal "#{cover_option} #{pathname}", @wp.get_parsed_options(:cover => pathname).strip, 'Pathname'
+    assert_match %r(#{cover_option} .+wicked_cover_pdf.+\.html), @wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
   end
 
   test 'should parse other options' do
-    wp = WickedPdf.new
-
     [
       :orientation, :page_size, :proxy, :username, :password, :dpi,
       :encoding, :user_style_sheet
     ].each do |o|
-      assert_equal "--#{o.to_s.tr('_', '-')} opts", wp.get_parsed_options(o => 'opts').strip
+      assert_equal "--#{o.to_s.tr('_', '-')} opts", @wp.get_parsed_options(o => 'opts').strip
     end
 
     [:cookie, :post].each do |o|
-      assert_equal "--#{o.to_s.tr('_', '-')} name value", wp.get_parsed_options(o => 'name value').strip
+      assert_equal "--#{o.to_s.tr('_', '-')} name value", @wp.get_parsed_options(o => 'name value').strip
 
       nv_formatter = proc { |number| "--#{o.to_s.tr('_', '-')} par#{number} val#{number}" }
-      assert_equal "#{nv_formatter.call(1)} #{nv_formatter.call(2)}", wp.get_parsed_options(o => ['par1 val1', 'par2 val2']).strip
+      assert_equal "#{nv_formatter.call(1)} #{nv_formatter.call(2)}", @wp.get_parsed_options(o => ['par1 val1', 'par2 val2']).strip
     end
 
     [:redirect_delay, :zoom, :page_offset].each do |o|
-      assert_equal "--#{o.to_s.tr('_', '-')} 5", wp.get_parsed_options(o => 5).strip
+      assert_equal "--#{o.to_s.tr('_', '-')} 5", @wp.get_parsed_options(o => 5).strip
     end
 
     [
@@ -183,7 +173,7 @@ class WickedPdfTest < ActiveSupport::TestCase
       :enable_plugins, :disable_internal_links, :disable_external_links,
       :print_media_type, :disable_smart_shrinking, :use_xserver, :no_background
     ].each do |o|
-      assert_equal "--#{o.to_s.tr('_', '-')}", wp.get_parsed_options(o => true).strip
+      assert_equal "--#{o.to_s.tr('_', '-')}", @wp.get_parsed_options(o => true).strip
     end
   end
 


### PR DESCRIPTION
We had a new WickedPdf instance being created in `test/unit/wicked_pdf_test.rb`.

Figured we should use it throughout rather than instantiating a fresh one in many of the tests.