### PR TITLE
Add window_status flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ class ThingsController < ApplicationController
                post:                           ['query QUERY_PARAM'],      # could be an array or a single string in a 'name value' format
                redirect_delay:                 NUMBER,
                javascript_delay:               NUMBER,
+               window_status:                  'TEXT',                     # wait to render until some JS sets window.status to the given string
                image_quality:                  NUMBER,
                no_pdf_compression:             true,
                zoom:                           FLOAT,

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -302,7 +302,8 @@ class WickedPdf
                                   :password,
                                   :encoding,
                                   :user_style_sheet,
-                                  :viewport_size])
+                                  :viewport_size,
+                                  :window_status])
       r += make_options(options, [:cookie,
                                   :post], '', :name_value)
       r += make_options(options, [:redirect_delay,


### PR DESCRIPTION
`--window-status="ready"` is an alternative to `--javascript-delay=5000` useful when the delay might be highly variable. wkhtmltopdf waits until some JS sets `window.status === "ready"` before rendering the HTML. A very useful option for this gem to allow.