### PR TITLE
Fix Rubocop errors and enforce in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
 env: WKHTMLTOPDF_BIN=/usr/bin/wkhtmltopdf
 script:
-  - bundle exec rake dummy_generate
-  - bundle exec rake test
+  - bundle exec rake
 matrix:
   include:
     - rvm: 1.8.7

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 
 desc 'Run RuboCop'
 task :rubocop do
-  return unless RUBY_VERSION > '1.9.2'
+  next unless RUBY_VERSION > '1.9.2'
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
 end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -87,7 +87,7 @@ class WickedPdf
     generated_pdf_file.rewind
     generated_pdf_file.binmode
     pdf = generated_pdf_file.read
-    fail "PDF could not be generated!\n Command Error: #{err}" if pdf && pdf.rstrip.empty?
+    raise "PDF could not be generated!\n Command Error: #{err}" if pdf && pdf.rstrip.empty?
     pdf
   rescue => e
     raise "Failed to execute:\n#{command}\nError: #{e}"

--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -21,7 +21,7 @@ class PdfHelperTest < ActionController::TestCase
     test 'should prerender header and footer :template options' do
       options = @ac.send(:prerender_header_and_footer,
                          :header => { :html => { :template => 'hf.html.erb' } })
-      assert_match %r(^file:\/\/\/.*wicked_header_pdf.*\.html), options[:header][:html][:url]
+      assert_match %r{^file:\/\/\/.*wicked_header_pdf.*\.html}, options[:header][:html][:url]
     end
   end
 end

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -6,7 +6,7 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
 
   if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
     test 'wicked_pdf_asset_base64 returns a base64 encoded asset' do
-      assert_match %r(data:text\/css;base64,.+), wicked_pdf_asset_base64('wicked.css')
+      assert_match %r{data:text\/css;base64,.+}, wicked_pdf_asset_base64('wicked.css')
     end
 
     test 'wicked_pdf_asset_path should return a url when assets are served by an asset server' do

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -143,7 +143,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     pathname = Rails.root.join('app', 'views', 'pdf', 'file.html')
     assert_equal "#{cover_option} http://example.org", @wp.get_parsed_options(:cover => 'http://example.org').strip, 'URL'
     assert_equal "#{cover_option} #{pathname}", @wp.get_parsed_options(:cover => pathname).strip, 'Pathname'
-    assert_match %r(#{cover_option} .+wicked_cover_pdf.+\.html), @wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
+    assert_match %r{#{cover_option} .+wicked_cover_pdf.+\.html}, @wp.get_parsed_options(:cover => '<html><body>HELLO</body></html>').strip, 'HTML'
   end
 
   test 'should parse other options' do

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'wicked_pdf/version'
+require 'English'
 
 Gem::Specification.new do |spec|
   spec.name          = 'wicked_pdf'
@@ -18,7 +19,7 @@ In other words, rather than dealing with a PDF generation DSL of some sort,
 you simply write an HTML view as you would normally, and let Wicked take care of the hard stuff.
 desc
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
Fixes the existing Rubocop errors and runs Rubucop in CI.

This should prevent future PRs like this. 😉 

Also, the `rubocop` `rake` task had a guard clause that was `return`ing, which is not allowed. This caused it to bomb on Ruby 1.9.2 in CI. I changed it to `next` which seems to be the proper way to do it.

If you want any of the Rubocop rules disabled instead, let me know. 

![rubocop](https://cloud.githubusercontent.com/assets/56081/15121636/b3a9232c-15d8-11e6-8be6-74a1cb392dd4.gif)
