### PR TITLE
Remove unnecessary require.

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,6 +1,4 @@
 module PdfHelper
-  require 'tempfile'
-
   def self.included(base)
     # Protect from trying to augment modules that appear
     # as the result of adding other gems.


### PR DESCRIPTION
`PdfHelper` module does not directly depend on 'tempfile'.
In this gem `WickedPdfTempfile` depends on 'tempfile'
and `PdfHelper` depends on `WickedPdfTempfile`.
So we need not to require 'tempfile' in `PdfHelper`.