### PR TITLE
Do not touch `new` file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,9 @@ desc 'Generate dummy application for test cases'
 task :dummy_generate do
   Rake::Task[:dummy_remove].invoke
   puts 'Creating dummy application to run tests'
-  prefix = (Rails::VERSION::MAJOR == 2) ? '' : 'new '
-  system("rails #{prefix}test/dummy")
-  system("touch #{prefix}test/dummy/db/schema.rb")
+  command = (Rails::VERSION::MAJOR == 2) ? '' : 'new'
+  system("rails #{command} test/dummy")
+  system('touch test/dummy/db/schema.rb')
   FileUtils.rm_r Dir.glob('test/dummy/test/*')
 end
 


### PR DESCRIPTION
`$ rake dummy_generate` executes `touch new test/dummy/db/schema.rb`,
this generates unnecessary "new" file.
This commit prevent to create "new" file.