### PR TITLE
To test as far as possible

### DIFF
--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -17,11 +17,9 @@ class PdfHelperTest < ActionController::TestCase
     @ac = nil
   end
 
-  if Rails::VERSION::MAJOR == 2
-    test 'should prerender header and footer :template options' do
-      options = @ac.send(:prerender_header_and_footer,
-                         :header => { :html => { :template => 'hf.html.erb' } })
-      assert_match %r{^file:\/\/\/.*wicked_header_pdf.*\.html}, options[:header][:html][:url]
-    end
+  test 'should prerender header and footer :template options' do
+    options = @ac.send(:prerender_header_and_footer,
+                       :header => { :html => { :template => 'hf.html.erb' } })
+    assert_match %r{^file:\/\/\/.*wicked_header_pdf.*\.html}, options[:header][:html][:url]
   end
 end

--- a/test/functional/wicked_pdf_helper_test.rb
+++ b/test/functional/wicked_pdf_helper_test.rb
@@ -2,25 +2,25 @@ require 'test_helper'
 require 'action_view/test_case'
 
 class WickedPdfHelperTest < ActionView::TestCase
+  test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in' do
+    assert_equal "<style type='text/css'>/* Wicked styles */\n</style>",
+                 wicked_pdf_stylesheet_link_tag('../../../fixtures/wicked')
+  end
+
+  test 'wicked_pdf_image_tag should return the same as image_tag when passed a full path' do
+    assert_equal image_tag("file:///#{Rails.root.join('public', 'images', 'pdf')}"),
+                 wicked_pdf_image_tag('pdf')
+  end
+
   if Rails::VERSION::MAJOR == 2
-    test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in' do
-      assert_equal "<style type='text/css'>/* Wicked styles */\n</style>",
-                   wicked_pdf_stylesheet_link_tag('../../../fixtures/wicked')
-    end
-
-    test 'wicked_pdf_image_tag should return the same as image_tag when passed a full path' do
-      assert_equal image_tag("file:///#{Rails.root.join('public', 'images', 'pdf')}"),
-                   wicked_pdf_image_tag('pdf')
-    end
-
     test 'wicked_pdf_javascript_src_tag should return the same as javascript_src_tag when passed a full path' do
       assert_equal javascript_src_tag("file:///#{Rails.root.join('public', 'javascripts', 'pdf')}", {}),
                    wicked_pdf_javascript_src_tag('pdf')
     end
+  end
 
-    test 'wicked_pdf_include_tag should return many wicked_pdf_javascript_src_tags' do
-      assert_equal [wicked_pdf_javascript_src_tag('foo'), wicked_pdf_javascript_src_tag('bar')].join("\n"),
-                   wicked_pdf_javascript_include_tag('foo', 'bar')
-    end
+  test 'wicked_pdf_include_tag should return many wicked_pdf_javascript_src_tags' do
+    assert_equal [wicked_pdf_javascript_src_tag('foo'), wicked_pdf_javascript_src_tag('bar')].join("\n"),
+                 wicked_pdf_javascript_include_tag('foo', 'bar')
   end
 end


### PR DESCRIPTION
Many test cases in `pdf_helper_test.rb` and
`wicked_pdf_helper_test.rb` are asserted only
Rails 2. But we can run some of them.
To increase test coverage, assert these test cases
in all Rails versions.