### PR TITLE
Move all modules and classes into `WickedPdf` namespace

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,112 +1,114 @@
-module PdfHelper
-  def self.included(base)
-    # Protect from trying to augment modules that appear
-    # as the result of adding other gems.
-    return if base != ActionController::Base
+class WickedPdf
+  module PdfHelper
+    def self.included(base)
+      # Protect from trying to augment modules that appear
+      # as the result of adding other gems.
+      return if base != ActionController::Base
 
-    base.class_eval do
-      alias_method_chain :render, :wicked_pdf
-      alias_method_chain :render_to_string, :wicked_pdf
-      after_filter :clean_temp_files
+      base.class_eval do
+        alias_method_chain :render, :wicked_pdf
+        alias_method_chain :render_to_string, :wicked_pdf
+        after_filter :clean_temp_files
+      end
     end
-  end
 
-  def render_with_wicked_pdf(options = nil, *args, &block)
-    if options.is_a?(Hash) && options.key?(:pdf)
-      log_pdf_creation
-      options[:basic_auth] = set_basic_auth(options)
-      make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
-    else
-      render_without_wicked_pdf(options, *args, &block)
+    def render_with_wicked_pdf(options = nil, *args, &block)
+      if options.is_a?(Hash) && options.key?(:pdf)
+        log_pdf_creation
+        options[:basic_auth] = set_basic_auth(options)
+        make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
+      else
+        render_without_wicked_pdf(options, *args, &block)
+      end
     end
-  end
 
-  def render_to_string_with_wicked_pdf(options = nil, *args, &block)
-    if options.is_a?(Hash) && options.key?(:pdf)
-      log_pdf_creation
-      options[:basic_auth] = set_basic_auth(options)
-      options.delete :pdf
-      make_pdf((WickedPdf.config || {}).merge(options))
-    else
-      render_to_string_without_wicked_pdf(options, *args, &block)
+    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+      if options.is_a?(Hash) && options.key?(:pdf)
+        log_pdf_creation
+        options[:basic_auth] = set_basic_auth(options)
+        options.delete :pdf
+        make_pdf((WickedPdf.config || {}).merge(options))
+      else
+        render_to_string_without_wicked_pdf(options, *args, &block)
+      end
     end
-  end
 
-  private
+    private
 
-  def log_pdf_creation
-    logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
-  end
+    def log_pdf_creation
+      logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
+    end
 
-  def set_basic_auth(options = {})
-    options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
-    return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
-    request.env['HTTP_AUTHORIZATION'].split(' ').last
-  end
+    def set_basic_auth(options = {})
+      options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
+      return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
+      request.env['HTTP_AUTHORIZATION'].split(' ').last
+    end
 
-  def clean_temp_files
-    return unless defined?(@hf_tempfiles)
-    @hf_tempfiles.each(&:close!)
-  end
+    def clean_temp_files
+      return unless defined?(@hf_tempfiles)
+      @hf_tempfiles.each(&:close!)
+    end
 
-  def make_pdf(options = {})
-    render_opts = {
-      :template => options[:template],
-      :layout => options[:layout],
-      :formats => options[:formats],
-      :handlers => options[:handlers]
-    }
-    render_opts[:locals] = options[:locals] if options[:locals]
-    render_opts[:file] = options[:file] if options[:file]
-    html_string = render_to_string(render_opts)
-    options = prerender_header_and_footer(options)
-    w = WickedPdf.new(options[:wkhtmltopdf])
-    w.pdf_from_string(html_string, options)
-  end
-
-  def make_and_send_pdf(pdf_name, options = {})
-    options[:wkhtmltopdf] ||= nil
-    options[:layout] ||= false
-    options[:template] ||= File.join(controller_path, action_name)
-    options[:disposition] ||= 'inline'
-    if options[:show_as_html]
+    def make_pdf(options = {})
       render_opts = {
         :template => options[:template],
         :layout => options[:layout],
         :formats => options[:formats],
-        :handlers => options[:handlers],
-        :content_type => 'text/html'
+        :handlers => options[:handlers]
       }
       render_opts[:locals] = options[:locals] if options[:locals]
       render_opts[:file] = options[:file] if options[:file]
-      render(render_opts)
-    else
-      pdf_content = make_pdf(options)
-      File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
-      send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
+      html_string = render_to_string(render_opts)
+      options = prerender_header_and_footer(options)
+      w = WickedPdf.new(options[:wkhtmltopdf])
+      w.pdf_from_string(html_string, options)
     end
-  end
 
-  # Given an options hash, prerenders content for the header and footer sections
-  # to temp files and return a new options hash including the URLs to these files.
-  def prerender_header_and_footer(options)
-    [:header, :footer].each do |hf|
-      next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
-      @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-      @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
-      options[hf][:html][:layout] ||= options[:layout]
-      render_opts = {
-        :template => options[hf][:html][:template],
-        :layout => options[hf][:html][:layout],
-        :formats => options[hf][:html][:formats],
-        :handlers => options[hf][:html][:handlers]
-      }
-      render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
-      render_opts[:file] = options[hf][:html][:file] if options[:file]
-      tf.write render_to_string(render_opts)
-      tf.flush
-      options[hf][:html][:url] = "file:///#{tf.path}"
+    def make_and_send_pdf(pdf_name, options = {})
+      options[:wkhtmltopdf] ||= nil
+      options[:layout] ||= false
+      options[:template] ||= File.join(controller_path, action_name)
+      options[:disposition] ||= 'inline'
+      if options[:show_as_html]
+        render_opts = {
+          :template => options[:template],
+          :layout => options[:layout],
+          :formats => options[:formats],
+          :handlers => options[:handlers],
+          :content_type => 'text/html'
+        }
+        render_opts[:locals] = options[:locals] if options[:locals]
+        render_opts[:file] = options[:file] if options[:file]
+        render(render_opts)
+      else
+        pdf_content = make_pdf(options)
+        File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
+        send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
+      end
     end
-    options
+
+    # Given an options hash, prerenders content for the header and footer sections
+    # to temp files and return a new options hash including the URLs to these files.
+    def prerender_header_and_footer(options)
+      [:header, :footer].each do |hf|
+        next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
+        @hf_tempfiles = [] unless defined?(@hf_tempfiles)
+        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+        options[hf][:html][:layout] ||= options[:layout]
+        render_opts = {
+          :template => options[hf][:html][:template],
+          :layout => options[hf][:html][:layout],
+          :formats => options[hf][:html][:formats],
+          :handlers => options[hf][:html][:handlers]
+        }
+        render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
+        render_opts[:file] = options[hf][:html][:file] if options[:file]
+        tf.write render_to_string(render_opts)
+        tf.flush
+        options[hf][:html][:url] = "file:///#{tf.path}"
+      end
+      options
+    end
   end
 end

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -2,43 +2,45 @@ require 'wicked_pdf/pdf_helper'
 require 'wicked_pdf/wicked_pdf_helper'
 require 'wicked_pdf/wicked_pdf_helper/assets'
 
-if defined?(Rails)
+class WickedPdf
+  if defined?(Rails)
 
-  if Rails::VERSION::MAJOR == 3
+    if Rails::VERSION::MAJOR == 3
 
-    class WickedRailtie < Rails::Railtie
-      initializer 'wicked_pdf.register' do |_app|
-        ActionController::Base.send :include, PdfHelper
-        if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
-          ActionView::Base.send :include, WickedPdfHelper::Assets
-        else
-          ActionView::Base.send :include, WickedPdfHelper
+      class WickedRailtie < Rails::Railtie
+        initializer 'wicked_pdf.register' do |_app|
+          ActionController::Base.send :include, PdfHelper
+          if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
+            ActionView::Base.send :include, WickedPdfHelper::Assets
+          else
+            ActionView::Base.send :include, WickedPdfHelper
+          end
         end
       end
-    end
 
-  elsif Rails::VERSION::MAJOR == 2
+    elsif Rails::VERSION::MAJOR == 2
 
-    unless ActionController::Base.instance_methods.include? 'render_with_wicked_pdf'
-      ActionController::Base.send :include, PdfHelper
-    end
-    unless ActionView::Base.instance_methods.include? 'wicked_pdf_stylesheet_link_tag'
-      ActionView::Base.send :include, WickedPdfHelper
-    end
-
-  else
-
-    class WickedRailtie < Rails::Railtie
-      initializer 'wicked_pdf.register' do |_app|
+      unless ActionController::Base.instance_methods.include? 'render_with_wicked_pdf'
         ActionController::Base.send :include, PdfHelper
-        ActionView::Base.send :include, WickedPdfHelper::Assets
       end
+      unless ActionView::Base.instance_methods.include? 'wicked_pdf_stylesheet_link_tag'
+        ActionView::Base.send :include, WickedPdfHelper
+      end
+
+    else
+
+      class WickedRailtie < Rails::Railtie
+        initializer 'wicked_pdf.register' do |_app|
+          ActionController::Base.send :include, PdfHelper
+          ActionView::Base.send :include, WickedPdfHelper::Assets
+        end
+      end
+
+    end
+
+    if Mime::Type.lookup_by_extension(:pdf).nil?
+      Mime::Type.register('application/pdf', :pdf)
     end
 
   end
-
-  if Mime::Type.lookup_by_extension(:pdf).nil?
-    Mime::Type.register('application/pdf', :pdf)
-  end
-
 end

--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -1,11 +1,13 @@
 require 'tempfile'
 
-class WickedPdfTempfile < Tempfile
-  # ensures the Tempfile's filename always keeps its extension
-  def initialize(filename, temp_dir = nil)
-    temp_dir ||= Dir.tmpdir
-    extension = File.extname(filename)
-    basename  = File.basename(filename, extension)
-    super([basename, extension], temp_dir)
+class WickedPdf
+  class WickedPdfTempfile < Tempfile
+    # ensures the Tempfile's filename always keeps its extension
+    def initialize(filename, temp_dir = nil)
+      temp_dir ||= Dir.tmpdir
+      extension = File.extname(filename)
+      basename  = File.basename(filename, extension)
+      super([basename, extension], temp_dir)
+    end
   end
 end

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -1,33 +1,35 @@
-module WickedPdfHelper
-  def self.root_path
-    String === Rails.root ? Pathname.new(Rails.root) : Rails.root
-  end
+class WickedPdf
+  module WickedPdfHelper
+    def self.root_path
+      String === Rails.root ? Pathname.new(Rails.root) : Rails.root
+    end
 
-  def self.add_extension(filename, extension)
-    filename.to_s.split('.').include?(extension) ? filename : "#{filename}.#{extension}"
-  end
+    def self.add_extension(filename, extension)
+      filename.to_s.split('.').include?(extension) ? filename : "#{filename}.#{extension}"
+    end
 
-  def wicked_pdf_stylesheet_link_tag(*sources)
-    css_dir = WickedPdfHelper.root_path.join('public', 'stylesheets')
-    css_text = sources.collect do |source|
-      source = WickedPdfHelper.add_extension(source, 'css')
-      "<style type='text/css'>#{File.read(css_dir.join(source))}</style>"
-    end.join("\n")
-    css_text.respond_to?(:html_safe) ? css_text.html_safe : css_text
-  end
+    def wicked_pdf_stylesheet_link_tag(*sources)
+      css_dir = WickedPdfHelper.root_path.join('public', 'stylesheets')
+      css_text = sources.collect do |source|
+        source = WickedPdfHelper.add_extension(source, 'css')
+        "<style type='text/css'>#{File.read(css_dir.join(source))}</style>"
+      end.join("\n")
+      css_text.respond_to?(:html_safe) ? css_text.html_safe : css_text
+    end
 
-  def wicked_pdf_image_tag(img, options = {})
-    image_tag "file:///#{WickedPdfHelper.root_path.join('public', 'images', img)}", options
-  end
+    def wicked_pdf_image_tag(img, options = {})
+      image_tag "file:///#{WickedPdfHelper.root_path.join('public', 'images', img)}", options
+    end
 
-  def wicked_pdf_javascript_src_tag(jsfile, options = {})
-    jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
-    src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
-    content_tag('script', '', { 'type' => Mime::JS, 'src' => path_to_javascript(src) }.merge(options))
-  end
+    def wicked_pdf_javascript_src_tag(jsfile, options = {})
+      jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
+      src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
+      content_tag('script', '', { 'type' => Mime::JS, 'src' => path_to_javascript(src) }.merge(options))
+    end
 
-  def wicked_pdf_javascript_include_tag(*sources)
-    js_text = sources.collect { |source| wicked_pdf_javascript_src_tag(source, {}) }.join("\n")
-    js_text.respond_to?(:html_safe) ? js_text.html_safe : js_text
+    def wicked_pdf_javascript_include_tag(*sources)
+      js_text = sources.collect { |source| wicked_pdf_javascript_src_tag(source, {}) }.join("\n")
+      js_text.respond_to?(:html_safe) ? js_text.html_safe : js_text
+    end
   end
 end

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -1,120 +1,122 @@
 require 'open-uri'
 
-module WickedPdfHelper
-  module Assets
-    ASSET_URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/
+class WickedPdf
+  module WickedPdfHelper
+    module Assets
+      ASSET_URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/
 
-    def wicked_pdf_asset_base64(path)
-      asset = Rails.application.assets.find_asset(path)
-      throw "Could not find asset '#{path}'" if asset.nil?
-      base64 = Base64.encode64(asset.to_s).gsub(/\s+/, '')
-      "data:#{asset.content_type};base64,#{Rack::Utils.escape(base64)}"
-    end
-
-    def wicked_pdf_stylesheet_link_tag(*sources)
-      stylesheet_contents = sources.collect do |source|
-        source = WickedPdfHelper.add_extension(source, 'css')
-        "<style type='text/css'>#{read_asset(source)}</style>"
-      end.join("\n")
-
-      stylesheet_contents.gsub(ASSET_URL_REGEX) do
-        if Regexp.last_match[1].starts_with?('data:')
-          "url(#{Regexp.last_match[1]})"
-        else
-          "url(#{wicked_pdf_asset_path(Regexp.last_match[1])})"
-        end
-      end.html_safe
-    end
-
-    def wicked_pdf_image_tag(img, options = {})
-      image_tag wicked_pdf_asset_path(img), options
-    end
-
-    def wicked_pdf_javascript_src_tag(jsfile, options = {})
-      jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
-      javascript_include_tag wicked_pdf_asset_path(jsfile), options
-    end
-
-    def wicked_pdf_javascript_include_tag(*sources)
-      sources.collect do |source|
-        source = WickedPdfHelper.add_extension(source, 'js')
-        "<script type='text/javascript'>#{read_asset(source)}</script>"
-      end.join("\n").html_safe
-    end
-
-    def wicked_pdf_asset_path(asset)
-      if (pathname = asset_pathname(asset).to_s) =~ URI_REGEXP
-        pathname
-      else
-        "file:///#{pathname}"
+      def wicked_pdf_asset_base64(path)
+        asset = Rails.application.assets.find_asset(path)
+        throw "Could not find asset '#{path}'" if asset.nil?
+        base64 = Base64.encode64(asset.to_s).gsub(/\s+/, '')
+        "data:#{asset.content_type};base64,#{Rack::Utils.escape(base64)}"
       end
-    end
 
-    private
+      def wicked_pdf_stylesheet_link_tag(*sources)
+        stylesheet_contents = sources.collect do |source|
+          source = WickedPdfHelper.add_extension(source, 'css')
+          "<style type='text/css'>#{read_asset(source)}</style>"
+        end.join("\n")
 
-    # borrowed from actionpack/lib/action_view/helpers/asset_url_helper.rb
-    URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
+        stylesheet_contents.gsub(ASSET_URL_REGEX) do
+          if Regexp.last_match[1].starts_with?('data:')
+            "url(#{Regexp.last_match[1]})"
+          else
+            "url(#{wicked_pdf_asset_path(Regexp.last_match[1])})"
+          end
+        end.html_safe
+      end
 
-    def asset_pathname(source)
-      if precompiled_or_absolute_asset?(source)
-        asset = asset_path(source)
-        pathname = prepend_protocol(asset)
-        if pathname =~ URI_REGEXP
-          # asset_path returns an absolute URL using asset_host if asset_host is set
+      def wicked_pdf_image_tag(img, options = {})
+        image_tag wicked_pdf_asset_path(img), options
+      end
+
+      def wicked_pdf_javascript_src_tag(jsfile, options = {})
+        jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
+        javascript_include_tag wicked_pdf_asset_path(jsfile), options
+      end
+
+      def wicked_pdf_javascript_include_tag(*sources)
+        sources.collect do |source|
+          source = WickedPdfHelper.add_extension(source, 'js')
+          "<script type='text/javascript'>#{read_asset(source)}</script>"
+        end.join("\n").html_safe
+      end
+
+      def wicked_pdf_asset_path(asset)
+        if (pathname = asset_pathname(asset).to_s) =~ URI_REGEXP
           pathname
         else
-          File.join(Rails.public_path, asset.sub(/\A#{Rails.application.config.action_controller.relative_url_root}/, ''))
+          "file:///#{pathname}"
         end
-      else
-        asset = Rails.application.assets.find_asset(source)
-        asset ? asset.pathname : File.join(Rails.public_path, source)
       end
-    end
 
-    # will prepend a http or default_protocol to a protocol relative URL
-    # or when no protcol is set.
-    def prepend_protocol(source)
-      protocol = WickedPdf.config[:default_protocol] || 'http'
-      if source[0, 2] == '//'
-        source = [protocol, ':', source].join
-      elsif source[0] != '/' && !source[0, 8].include?('://')
-        source = [protocol, '://', source].join
-      end
-      source
-    end
+      private
 
-    def precompiled_or_absolute_asset?(source)
-      Rails.configuration.assets.compile == false ||
-        source.to_s[0] == '/' ||
-        source.to_s.match(/\Ahttps?\:\/\//)
-    end
+      # borrowed from actionpack/lib/action_view/helpers/asset_url_helper.rb
+      URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}
 
-    def read_asset(source)
-      if precompiled_or_absolute_asset?(source)
-        pathname = asset_pathname(source)
-        if pathname =~ URI_REGEXP
-          read_from_uri(pathname)
-        elsif File.file?(pathname)
-          IO.read(pathname)
+      def asset_pathname(source)
+        if precompiled_or_absolute_asset?(source)
+          asset = asset_path(source)
+          pathname = prepend_protocol(asset)
+          if pathname =~ URI_REGEXP
+            # asset_path returns an absolute URL using asset_host if asset_host is set
+            pathname
+          else
+            File.join(Rails.public_path, asset.sub(/\A#{Rails.application.config.action_controller.relative_url_root}/, ''))
+          end
+        else
+          asset = Rails.application.assets.find_asset(source)
+          asset ? asset.pathname : File.join(Rails.public_path, source)
         end
-      else
-        Rails.application.assets.find_asset(source).to_s
       end
-    end
 
-    def read_from_uri(uri)
-      encoding = ':UTF-8' if RUBY_VERSION > '1.8'
-      asset = open(uri, "r#{encoding}", &:read)
-      asset = gzip(asset) if WickedPdf.config[:expect_gzipped_remote_assets]
-      asset
-    end
+      # will prepend a http or default_protocol to a protocol relative URL
+      # or when no protcol is set.
+      def prepend_protocol(source)
+        protocol = WickedPdf.config[:default_protocol] || 'http'
+        if source[0, 2] == '//'
+          source = [protocol, ':', source].join
+        elsif source[0] != '/' && !source[0, 8].include?('://')
+          source = [protocol, '://', source].join
+        end
+        source
+      end
 
-    def gzip(asset)
-      stringified_asset = StringIO.new(asset)
-      gzipper = Zlib::GzipReader.new(stringified_asset)
-      gzipper.read
-    rescue Zlib::GzipFile::Error
-      nil
+      def precompiled_or_absolute_asset?(source)
+        Rails.configuration.assets.compile == false ||
+          source.to_s[0] == '/' ||
+          source.to_s.match(/\Ahttps?\:\/\//)
+      end
+
+      def read_asset(source)
+        if precompiled_or_absolute_asset?(source)
+          pathname = asset_pathname(source)
+          if pathname =~ URI_REGEXP
+            read_from_uri(pathname)
+          elsif File.file?(pathname)
+            IO.read(pathname)
+          end
+        else
+          Rails.application.assets.find_asset(source).to_s
+        end
+      end
+
+      def read_from_uri(uri)
+        encoding = ':UTF-8' if RUBY_VERSION > '1.8'
+        asset = open(uri, "r#{encoding}", &:read)
+        asset = gzip(asset) if WickedPdf.config[:expect_gzipped_remote_assets]
+        asset
+      end
+
+      def gzip(asset)
+        stringified_asset = StringIO.new(asset)
+        gzipper = Zlib::GzipReader.new(stringified_asset)
+        gzipper.read
+      rescue Zlib::GzipFile::Error
+        nil
+      end
     end
   end
 end

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'action_view/test_case'
 
 class WickedPdfHelperAssetsTest < ActionView::TestCase
-  include WickedPdfHelper::Assets
+  include WickedPdf::WickedPdfHelper::Assets
 
   if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
     test 'wicked_pdf_asset_base64 returns a base64 encoded asset' do
@@ -112,13 +112,13 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
     end
 
     test 'WickedPdfHelper::Assets::ASSET_URL_REGEX should match various URL data type formats' do
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'/asset/stylesheets/application.css\');'
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("/asset/stylesheets/application.css");'
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(/asset/stylesheets/application.css);'
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'http://assets.domain.com/dummy.png\');'
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("http://assets.domain.com/dummy.png");'
-      assert_match WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(http://assets.domain.com/dummy.png);'
-      assert_no_match WickedPdfHelper::Assets::ASSET_URL_REGEX, '.url { \'http://assets.domain.com/dummy.png\' }'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'/asset/stylesheets/application.css\');'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("/asset/stylesheets/application.css");'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(/asset/stylesheets/application.css);'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(\'http://assets.domain.com/dummy.png\');'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url("http://assets.domain.com/dummy.png");'
+      assert_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, 'url(http://assets.domain.com/dummy.png);'
+      assert_no_match WickedPdf::WickedPdfHelper::Assets::ASSET_URL_REGEX, '.url { \'http://assets.domain.com/dummy.png\' }'
     end
 
     test 'prepend_protocol should properly set the protocol when the asset is precompiled' do

--- a/test/functional/wicked_pdf_helper_test.rb
+++ b/test/functional/wicked_pdf_helper_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'action_view/test_case'
 
 class WickedPdfHelperTest < ActionView::TestCase
+  include WickedPdf::WickedPdfHelper
+
   test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in' do
     assert_equal "<style type='text/css'>/* Wicked styles */\n</style>",
                  wicked_pdf_stylesheet_link_tag('../../../fixtures/wicked')


### PR DESCRIPTION
It is not good to expose modules and classes except the root
namespace (`WickedPdf`), because someone define same name
modules or classes.
In this case, `PdfHelper` is a very common name for someone
to define a same name module.