### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -8,7 +8,7 @@ class WickedPdf
       base.class_eval do
         alias_method_chain :render, :wicked_pdf
         alias_method_chain :render_to_string, :wicked_pdf
-        after_filter :clean_temp_files
+        after_action :clean_temp_files
       end
     end
 

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -24,7 +24,7 @@ class WickedPdf
     def wicked_pdf_javascript_src_tag(jsfile, options = {})
       jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
       src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
-      content_tag('script', '', { 'type' => Mime::JS, 'src' => path_to_javascript(src) }.merge(options))
+      content_tag('script', '', { 'type' => Mime[:js], 'src' => path_to_javascript(src) }.merge(options))
     end
 
     def wicked_pdf_javascript_include_tag(*sources)


### PR DESCRIPTION
Hi, I wanted to change the after_filter call in lib/wicked_pdf/pdf_helper.rb to make it compliant with the new Rails 5 syntax and ended up also clearing a deprecation warning from running the wicked pdf tests, by changing Mime::JS to Mime[:js] in lib/wicked_pdf/wicked_pdf_helper.rb.

The test suite has a failing test regarding javascript but it was already failing before and I didn't try to implement or change it, but everything else is green.

This is my first open source contribution, and I'm excited to hear some feedback! 
