### PR TITLE
Fix how to specify layout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ class ThingsController < ApplicationController
                disposition:                    'attachment',                 # default 'inline'
                template:                       'things/show',
                file:                           "#{Rails.root}/files/foo.erb"
-               layout:                         'pdf',                        # for a pdf.html.erb file
+               layout:                         'pdf.html',                        # for a pdf.html.erb file
                wkhtmltopdf:                    '/usr/local/bin/wkhtmltopdf', # path to binary
                show_as_html:                   params.key?('debug'),         # allow debugging based on url param
                orientation:                    'Landscape',                  # default Portrait


### PR DESCRIPTION
Used to say just "pdf", but this is incorrect. Must specify "pdf.html"

This page has the correct documentation: https://github.com/mileszs/wicked_pdf/wiki/Configuration
