### PR TITLE
Fix wkhtmltopdf path detection when HOME environment variable is unset

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -328,7 +328,8 @@ class WickedPdf
   end
 
   def find_wkhtmltopdf_binary_path
-    possible_locations = (ENV['PATH'].split(':') + %w(/usr/bin /usr/local/bin ~/bin)).uniq
+    possible_locations = (ENV['PATH'].split(':') + %w(/usr/bin /usr/local/bin)).uniq
+    possible_locations += %w(~/bin) if ENV.key?('HOME')
     exe_path ||= WickedPdf.config[:exe_path] unless WickedPdf.config.empty?
     exe_path ||= begin
       detected_path = (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp


### PR DESCRIPTION
If running in an environment where the HOME environment variable is not set, then the File.expand_path possibly called later on would throw a `couldn't find HOME environment -- expanding ~` error. This fixes it by only appending `~/bin` to the search path if the HOME environment variable is actually set.
