### PR TITLE
Adds BOM to intermediary html file

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -54,6 +54,7 @@ class WickedPdf
     options.merge!(WickedPdf.config) { |_key, option, _config| option }
     string_file = WickedPdfTempfile.new('wicked_pdf.html', options[:temp_path])
     string_file.binmode
+    string_file.write("\uFEFF")
     string_file.write(string)
     string_file.close
 


### PR DESCRIPTION
Popular js apis use UTF-8 symbols[1]. Even though UTF-8 is the default encoding for Ruby string since v2.0[2], BOM is not added to IO streams by default.

This commit adds the UTF-8 BOM marker (`\uFEFF`) to the intermediary html generated by wickedpdf. This seems to be necessary for wkhtml to properly identify the file as UTF-8. Without the BOM marker, although the rest of the file is encoded correctly, js fails on the first non-ascii symbol (see [1]) with a SyntaxError.

Related discussion: https://github.com/mileszs/wicked_pdf/issues/581

**maintainers/reviewers**: I couldn't get the tests to run (error log [here](https://gist.github.com/lbrito1/f9037061a0e4003d81799cab92da95de)) nor am I sure if this PR warrants a test or test modification. Let me know either way.
#### Notes

[1] e.g. D3 charting api https://github.com/d3/d3.github.com/blob/5295daf46336856c5d7a6d3a4818bf23a231b31e/d3.v3.js#L1261
[2] https://ruby-doc.org/core-2.2.0/Encoding.html#class-Encoding-label-Script+encoding
