### PR TITLE
default_protocol in list of available config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ class ThingsController < ApplicationController
                page_width:                     NUMBER,
                save_to_file:                   Rails.root.join('pdfs', "#{filename}.pdf"),
                save_only:                      false,                        # depends on :save_to_file being set first
+               default_protocol:               'http',
                proxy:                          'TEXT',
                basic_auth:                     false                         # when true username & password are automatically sent from session
                username:                       'TEXT',


### PR DESCRIPTION
`default_protocol` is an available config option that is not documented anywhere. Add it to the list of available options so that others can configure WickedPdf fully.