### PR TITLE
Remove extraneous logging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ matrix:
       gemfile: gemfiles/4.2.gemfile
     - rvm: 2.3.0
       gemfile: gemfiles/5.0.gemfile
-    - rvm: 2.2.2
-      gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.3.0
-      gemfile: gemfiles/rails_edge.gemfile
   allow_failures:
     - rvm: 1.9.2
       gemfile: gemfiles/3.0.gemfile
@@ -54,4 +50,8 @@ matrix:
       gemfile: gemfiles/3.2.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/4.0.gemfile
+    - rvm: 2.2.2
+      gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails_edge.gemfile
     - rvm: ruby-head

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -105,7 +105,7 @@ class WickedPdf
   end
 
   def print_command(cmd)
-    Rails.logger.debug '*' * 15 + cmd + '*' * 15
+    Rails.logger.debug '[wicked_pdf]: ' + cmd
   end
 
   def retrieve_binary_version

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -35,7 +35,6 @@ class WickedPdf
 
     def render_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
       else
@@ -45,7 +44,6 @@ class WickedPdf
 
     def render_to_string_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        log_pdf_creation
         options[:basic_auth] = set_basic_auth(options)
         options.delete :pdf
         make_pdf((WickedPdf.config || {}).merge(options))
@@ -55,10 +53,6 @@ class WickedPdf
     end
 
     private
-
-    def log_pdf_creation
-      logger.info '*' * 15 + 'WICKED' + '*' * 15 if logger && logger.respond_to?(:info)
-    end
 
     def set_basic_auth(options = {})
       options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }


### PR DESCRIPTION
The `****************WICKED****************` log is unnecessary, as are the extra `*`'s around the command.

Instead of using `*`, prefix the actual command with `[wicked_pdf]:` to make it easier to identify the source of the command.
