### PR TITLE
Update README.md with examples for Super Advanced Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ pdf = WickedPdf.new.pdf_from_url('https://github.com/mileszs/wicked_pdf')
 
 # create a pdf from string using templates, layouts and content option for header or footer
 pdf = WickedPdf.new.pdf_from_string(
-  render_to_string('templates/pdf', layout: 'pdfs/layout_pdf'),
+  render_to_string('templates/pdf', layout: 'pdfs/layout_pdf.html'),
   footer: {
     content: render_to_string(
   		'templates/footer',
-  		layout: 'pdfs/layout_pdf'
+  		layout: 'pdfs/layout_pdf.html'
   	)
   }
 )

--- a/README.md
+++ b/README.md
@@ -270,7 +270,18 @@ pdf = WickedPdf.new.pdf_from_url('https://github.com/mileszs/wicked_pdf')
 pdf = WickedPdf.new.pdf_from_string(
   render_to_string('templates/pdf', layout: 'pdfs/layout_pdf'),
   footer: {
-    content: render_to_string(layout: 'pdfs/layout_pdf')
+    content: render_to_string(
+  		'templates/footer',
+  		layout: 'pdfs/layout_pdf'
+  	)
+  }
+)
+
+# It is possible to use footer/header templates without a layout, in that case you need to provide a valid HTML document
+pdf = WickedPdf.new.pdf_from_string(
+  render_to_string('templates/full_pdf_template'),
+  header: {
+    content: render_to_string('templates/full_header_template')
   }
 )
 


### PR DESCRIPTION
Hello,

It might be obvious how to use 
```
render_to_string('templates/pdf', layout: 'pdfs/layout_pdf.html')
```
method, but I faced the same issue several times: if footer / header is used with **content** option, PDF is generated with multiple footers for every string of a general template, if there is no **layout** option. No errors, no warnings 🤔 And templates look fine and everything is fine ("I just fix some css" 😄) but PDF contains 64 pages with footers. A couple of hours later I got it: the document was an incorrect HTML document.
I've added examples and a note, I think it can be helpful 