### PR TITLE
Positively use ActionController::Base.helpers.asset_path

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -58,7 +58,7 @@ class WickedPdf
 
       def asset_pathname(source)
         if precompiled_or_absolute_asset?(source)
-          asset = asset_path(source)
+          asset = ActionController::Base.helpers.asset_path(source)
           pathname = prepend_protocol(asset)
           if pathname =~ URI_REGEXP
             # asset_path returns an absolute URL using asset_host if asset_host is set


### PR DESCRIPTION
For some reason that I couldn't figure out I had to change this to make paths work in my production environment. Not sure if it applies to other setups as well.