### PR TITLE
Handle Rails module defined without Rails env

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -195,24 +195,26 @@ class WickedPdf
 
   def parse_header_footer(options)
     r = []
-    [:header, :footer].collect do |hf|
-      next if options[hf].blank?
-      opt_hf = options[hf]
-      r += make_options(opt_hf, [:center, :font_name, :left, :right], hf.to_s)
-      r += make_options(opt_hf, [:font_size, :spacing], hf.to_s, :numeric)
-      r += make_options(opt_hf, [:line], hf.to_s, :boolean)
-      if options[hf] && options[hf][:content]
-        @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
-        tf.write options[hf][:content]
-        tf.flush
-        options[hf][:html] = {}
-        options[hf][:html][:url] = "file:///#{tf.path}"
+    unless options.blank?
+      [:header, :footer].collect do |hf|
+        next if options[hf].blank?
+        opt_hf = options[hf]
+        r += make_options(opt_hf, [:center, :font_name, :left, :right], hf.to_s)
+        r += make_options(opt_hf, [:font_size, :spacing], hf.to_s, :numeric)
+        r += make_options(opt_hf, [:line], hf.to_s, :boolean)
+        if options[hf] && options[hf][:content]
+          @hf_tempfiles = [] unless defined?(@hf_tempfiles)
+          @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+          tf.write options[hf][:content]
+          tf.flush
+          options[hf][:html] = {}
+          options[hf][:html][:url] = "file:///#{tf.path}"
+        end
+        unless opt_hf[:html].blank?
+          r += make_option("#{hf}-html", opt_hf[:html][:url]) unless opt_hf[:html][:url].blank?
+        end
       end
-      unless opt_hf[:html].blank?
-        r += make_option("#{hf}-html", opt_hf[:html][:url]) unless opt_hf[:html][:url].blank?
-      end
-    end unless options.blank?
+    end
     r
   end
 

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -96,7 +96,7 @@ class WickedPdf
   private
 
   def in_development_mode?
-    return Rails.env == 'development' if defined?(Rails)
+    return Rails.env == 'development' if defined?(Rails.env)
     RAILS_ENV == 'development' if defined?(RAILS_ENV)
   end
 

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -3,7 +3,7 @@ require 'wicked_pdf/wicked_pdf_helper'
 require 'wicked_pdf/wicked_pdf_helper/assets'
 
 class WickedPdf
-  if defined?(Rails)
+  if defined?(Rails.env)
 
     if Rails::VERSION::MAJOR >= 5
 


### PR DESCRIPTION
Gems like rails-html-sanitizer open `Rails` module without
actually requiring Rails. Instead check if Rails.env is defined.

Similar to: https://github.com/rails/activeresource/pull/216