### PR TITLE
Fix typo for release date of v1.1.0 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.1.0] - 2016-09-30
+## [1.1.0] - 2016-08-30
 ### Added
 - Support Rails 5.x and Sprockets 3.x
 - Support `window_status: 'somestring'` option, to instruct wkhtmltopdf to wait until the browser `window.status` is equal to the supplied string. This can be useful to force rendering to wait [as explained quite well here](https://spin.atomicobject.com/2015/08/29/ember-app-done-loading/)


### PR DESCRIPTION
Looks like there was a typo in the release date for v1.1.0 on the CHANGELOG in 6392bea1fe3a41682dfd7c20fd9c179b5a758f59, since Rubygems (and the date that commit was created) shows it was released on August 30th, not Sept 30th.

Also, there should be a `tag` pushed to the repository for that release, which is currently missing.