### PR TITLE
Assets helper Sprockets 4 compatibility fix.

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -68,7 +68,12 @@ class WickedPdf
           end
         else
           asset = find_asset(source)
-          asset ? asset.filename : File.join(Rails.public_path, source)
+          if asset
+            # older versions need pathname, Sprockets 4 supports only filename
+            asset.respond_to?(:filename) ? asset.filename : asset.pathname
+          else
+            File.join(Rails.public_path, source)
+          end
         end
       end
 

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -68,7 +68,7 @@ class WickedPdf
           end
         else
           asset = find_asset(source)
-          asset ? asset.pathname : File.join(Rails.public_path, source)
+          asset ? asset.filename : File.join(Rails.public_path, source)
         end
       end
 


### PR DESCRIPTION
Pathname attr reader was removed/deprecated. Only filename is available in Sprockets 4.x.