### PR TITLE
WIP: Support for using phantomjs in addition to wkhtmltopdf

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -67,8 +67,15 @@ class WickedPdf
     # merge in global config options
     options.merge!(WickedPdf.config) { |_key, option, _config| option }
     generated_pdf_file = WickedPdfTempfile.new('wicked_pdf_generated_file.pdf', options[:temp_path])
-    command = [@exe_path]
-    command << '-q' unless on_windows? # suppress errors on stdout
+
+    if WickedPdf.config[:phantomjs_exe_path]
+      command = [WickedPdf.config[:phantomjs_exe_path]]
+      spec = Gem::Specification.find_by_name('wicked_pdf')
+      command << File.join(spec.gem_dir, 'lib', 'wicked_pdf', 'rasterize.js')
+    else
+      command = [@exe_path]
+      command << '-q' unless on_windows? # suppress errors on stdout
+    end
     command += parse_options(options)
     command << url
     command << generated_pdf_file.path.to_s

--- a/lib/wicked_pdf/rasterize.js
+++ b/lib/wicked_pdf/rasterize.js
@@ -1,0 +1,45 @@
+"use strict";
+var page = require('webpage').create(),
+    system = require('system'),
+    format = 'A4',
+    margin = '10mm',
+    orientation = 'portrait',
+    address, output;
+
+
+if (system.args.length < 3) {
+    phantom.exit(1);
+} else {
+    address = system.args[system.args.length-2];
+    output = system.args[system.args.length-1];
+
+    for(var i=1;i<system.args.length-2;i+=2) {
+        switch(system.args[i]) {
+            case '--page-size':
+                format = system.args[i+1];
+                break;
+            case '--orientation':
+                orientation = system.args[i+1];
+                break;
+            case '--zoom':
+                page.zoomFactor = system.args[i+1];
+                break;
+            default:
+                console.log("Unknown argument: " + system.args[i])
+        }
+    }
+
+    page.paperSize = { format: format, orientation: orientation, margin: margin};
+
+    page.open(address, function (status) {
+        if (status !== 'success') {
+            console.log('Unable to load the address!');
+            phantom.exit(1);
+        } else {
+            window.setTimeout(function () {
+                page.render(output);
+                phantom.exit();
+            }, 200);
+        }
+    });
+}


### PR DESCRIPTION
Initial proof of concept for using phantomjs instead of wkhtmltopdf.
Supports the following properties: page size (format), orientation, and zoom.
To use set the phantomjs exec path in properties:
`phantomjs_exe_path: '/usr/local/bin/phantomjs'
`
I have tried to minimize changes in existing code.

It should also be noted that rasterize.js is based on the official example from Phantomjs:
https://github.com/ariya/phantomjs/blob/master/examples/rasterize.js