### PR TITLE
Fix NameError: uninitialized constant Mime::JS in Rails 5.1.0 beta

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -23,8 +23,9 @@ class WickedPdf
 
     def wicked_pdf_javascript_src_tag(jsfile, options = {})
       jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
+      type = ::Mime.respond_to?(:[]) ? ::Mime[:js] : ::Mime::JS # ::Mime[:js] cannot be used in Rails 2.3.
       src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
-      content_tag('script', '', { 'type' => Mime::JS, 'src' => path_to_javascript(src) }.merge(options))
+      content_tag('script', '', { 'type' => type, 'src' => path_to_javascript(src) }.merge(options))
     end
 
     def wicked_pdf_javascript_include_tag(*sources)


### PR DESCRIPTION
Thank you for your nice gem.

I found Travis CI tests with Rails edge(5.1.0 beta) gemfile are failed by `NameError: uninitialized constant Mime::JS`.

In Rails 5.1.0 beta, `::Mime::JS` and other constants are removed by this [PR](https://github.com/rails/rails/pull/26746/files#diff-c5146df11f35304765e9ceebed108f57).

I fixed this problem using `::Mime[:js]`.

But in Rails 2.3, `::Mime[:js]` cannot be used because `::Mime.[]` is not defined.
So I checked `::Mime.[]` is defined or not using `respond_to?`, and if `::Mime.[]` is not defined, then I use `::Mime::JS`.

Please check my PR.
Thank you.