### PR TITLE
Fix rubocop error

### DIFF
--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -14,11 +14,9 @@ module ActionControllerMock
       [:base]
     end
 
-    def render_to_string
-    end
+    def render_to_string; end
 
-    def self.after_action(_)
-    end
+    def self.after_action(_); end
   end
 end
 


### PR DESCRIPTION
The last Travis CI build is failed due to rubocop errors.

```
Offenses:

test/functional/pdf_helper_test.rb:17:5: C: Put empty method definitions on a single line.
    def render_to_string ...
    ^^^^^^^^^^^^^^^^^^^^
test/functional/pdf_helper_test.rb:20:5: C: Put empty method definitions on a single line.
    def self.after_action(_) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^
```

By default rubocop configuration, empty method definitions must be written in one line like `def empty_method; end`.

http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod

So I fixed those errors to modify empty method definitions written in one line.

If you don't like one line method definition, it can be resolved by adding following configuration to [rubocop.yml](https://github.com/mileszs/wicked_pdf/blob/master/.rubocop.yml).

```
Style/EmptyMethod:
  EnforcedStyle: expanded
```

Please check my PR.

Thanks