### PR TITLE
Fix Rails 5 deprecation notice with conditional calling of appropriate hook

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -8,7 +8,11 @@ class WickedPdf
       base.class_eval do
         alias_method_chain :render, :wicked_pdf
         alias_method_chain :render_to_string, :wicked_pdf
-        after_filter :clean_temp_files
+        if respond_to?(:after_action?)
+          after_action :clean_temp_files
+        else
+          after_filter :clean_temp_files
+        end
       end
     end
 


### PR DESCRIPTION
New pull request without failing code for Rails versions > 3 (didn't test for earlier). As suggested, the correct hook is being called if defined, otherwise failing gracefully.

Thanks for the tips!