### PR TITLE
Improve documentation on `exe_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If your wkhtmltopdf executable is not on your webserver's path, you can configur
 
 ```ruby
 WickedPdf.config = {
-  exe_path: '/usr/local/bin/wkhtmltopdf'
+  exe_path: '#{ENV['GEM_HOME']}/bin/wkhtmltopdf'
 }
 ```
 


### PR DESCRIPTION
My server was raising this error after a gem update:

```
Bad wkhtmltopdf's path: '/home/nginx' is not a directory.
Bundler will use '/tmp/bundler/home/root' as your home directory temporarily.
/var/deploy/timiapp.com/web_head/shared/bundle/ruby/2.3.0/bin/wkhtmltopdf
```

The fix is quite easy and can be found in this StackOverflow post: http://stackoverflow.com/a/41754326/616863

```ruby
 WickedPdf.config = {
  exe_path: '#{ENV['GEM_HOME']}/bin/wkhtmltopdf'
 }
```

With this PR I propose that this is the default in the documentation.

