### PR TITLE
Add gemspec requirements attribute

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -23,6 +23,8 @@ desc
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+  
+  spec.requirements << "wkhtmltopdf"
 
   spec.add_dependency 'activesupport'
 


### PR DESCRIPTION
This information will appear on the gem's page on rubygems.org.
http://guides.rubygems.org/specification-reference/#requirements