### PR TITLE
Fix method name when checking if controllers respond to `after_action`

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -8,7 +8,7 @@ class WickedPdf
       base.class_eval do
         alias_method_chain :render, :wicked_pdf
         alias_method_chain :render_to_string, :wicked_pdf
-        if respond_to?(:after_action?)
+        if respond_to?(:after_action)
           after_action :clean_temp_files
         else
           after_filter :clean_temp_files

--- a/test/functional/pdf_helper_test.rb
+++ b/test/functional/pdf_helper_test.rb
@@ -5,6 +5,8 @@ module ActionController
     def render_to_string(opts = {})
       opts.to_s
     end
+
+    def self.alias_method_chain(_, _); end
   end
 end
 
@@ -81,6 +83,14 @@ class PdfHelperTest < ActionController::TestCase
         ActionController.send(:remove_const, :Base)
         ActionController.const_set(:Base, OriginalBase)
       end
+    end
+  end
+
+  test 'should call after_action instead of after_filter when able' do
+    ActionController::Base.expects(:after_filter).with(:clean_temp_files).never
+    ActionController::Base.expects(:after_action).with(:clean_temp_files).once
+    ActionController::Base.class_eval do
+      include ::WickedPdf::PdfHelper
     end
   end
 end


### PR DESCRIPTION
https://github.com/mileszs/wicked_pdf/pull/630 used `after_action` in place of `after_filter` when it's available, since `after_filter` is deprecated in Rails 5.0. However, it was checking if the base class responded to `after_action?` (with a question mark appended) by accident.