### PR TITLE
Provide the base_path for asset lookup

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -79,9 +79,9 @@ class WickedPdf
 
       def find_asset(path)
         if Rails.application.assets.respond_to?(:find_asset)
-          Rails.application.assets.find_asset(path)
+          Rails.application.assets.find_asset(path, base_path: Rails.application.root.to_s)
         else
-          Sprockets::Railtie.build_environment(Rails.application).find_asset(path)
+          Sprockets::Railtie.build_environment(Rails.application).find_asset(path, base_path: Rails.application.root.to_s)
         end
       end
 


### PR DESCRIPTION
First, thanks for wicked_pdf! :green_heart: 

Ran into this problem while upgrading sprockets on our application
a rather lengthy debugging session through sprockets and friends
ended up here showing that the asset could be found if the
base_path was supplied. Iirc it's optional and should only
help - tbh it's a bit ago so don't have all the code in my
head anymore :)

edit: also we are running this in production so at least for us it works (tm) with the newest sprockets