### PR TITLE
Avoid using the shell to locate wkhtmltopdf in a Bundler environment

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -336,7 +336,7 @@ class WickedPdf
     possible_locations += %w[~/bin] if ENV.key?('HOME')
     exe_path ||= WickedPdf.config[:exe_path] unless WickedPdf.config.empty?
     exe_path ||= begin
-      detected_path = (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
+      detected_path = (defined?(Bundler) ? Bundler.which('wkhtmltopdf') : `which wkhtmltopdf`).chomp
       detected_path.present? && detected_path
     rescue StandardError
       nil

--- a/test/unit/wkhtmltopdf_location_test.rb
+++ b/test/unit/wkhtmltopdf_location_test.rb
@@ -1,0 +1,50 @@
+
+
+class WkhtmltopdfLocationTest < ActiveSupport::TestCase
+  setup do
+    @saved_config = WickedPdf.config
+    WickedPdf.config = {}
+  end
+
+  teardown do
+    WickedPdf.config = @saved_config
+  end
+
+  test 'should correctly locate wkhtmltopdf without bundler' do
+    bundler_module = Bundler
+    Object.send(:remove_const, :Bundler)
+
+    assert_nothing_raised do
+      WickedPdf.new
+    end
+
+    Object.const_set(:Bundler, bundler_module)
+  end
+
+  test 'should correctly locate wkhtmltopdf with bundler' do
+    assert_nothing_raised do
+      WickedPdf.new
+    end
+  end
+
+  class LocationNonWritableTest < ActiveSupport::TestCase
+    setup do
+      @saved_config = WickedPdf.config
+      WickedPdf.config = {}
+
+      @old_home = ENV['HOME']
+      ENV['HOME'] = '/not/a/writable/directory'
+    end
+
+    teardown do
+      WickedPdf.config = @saved_config
+      ENV['HOME'] = @old_home
+    end
+
+    test 'should correctly locate wkhtmltopdf with bundler while HOME is set to a non-writable directory' do
+      assert_nothing_raised do
+        WickedPdf.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, `wicked_pdf` suffers from the same issue the `pdfkit` does (according to pdfkit/pdfkit#388) where it picks up warning information introduced in `bundle 1.4.x` when the `HOME` environment variable points to a non-writable directory. When the information is not specified by configuration and the `wicked_pdf` is being used in a `bundler` environment, `wicked_pdf` attempts to use `bundle exec which wkhtmltopdf` which will output something like:

```
`/not/a/writable/directory` is not a directory.
 Bundler will use `/tmp/bundler/home/travis' as your home directory temporarily.
 /usr/bin/wkhtmltopdf
```

Which will then trigger a failure in [`WickedPdf#initialize`] caused by getting the full text above from the call to the shell in [`WickedPdf#find_wkhtmltopdf_binary_path`](https://github.com/mileszs/wicked_pdf/blob/3ed148cddb6ff4976fa61671ca795c4d764a01ca/lib/wicked_pdf.rb#L339).

Calling out to the shell itself seems odd when calling the shell through `bundler`. Instead, this change uses the long-present [`Bundler.which`](https://github.com/bundler/bundler/blob/7f4c1a81b7b92e234fce0e3592d27c396d2451ac/lib/bundler.rb#L386-L397) method which does the same work, but will give back a consistent result.

## Note on Workaround

Similar to the `pdfkit` issue, this can be worked around by explicitly setting `exe_path` when configuring `wicked_pdf`, per the readme.