### PR TITLE
Pin to older mocha version

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -33,6 +33,6 @@ DESC
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.50.0' if RUBY_VERSION >= '2.0.0'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'mocha'
+  spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Tests are currently failing, and emitting this message:

```
Mocha::NotInitializedError: Mocha methods cannot be used outside the context of a test
```

This PR attempts to fix the tests so that other contributions can be evaluatated.

Ideally, we can also fix whatever is causing this in newer versions.