### PR TITLE
Raise exception on all pdf generation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ class ThingsController < ApplicationController
                no_background:                  true,
                viewport_size:                  'TEXT',                    # available only with use_xserver or patched QT
                extra:                          '',                        # directly inserted into the command to wkhtmltopdf
+               raise_on_all_errors:            nil,                       # raise error for any stderr output.  Such as missing media, image assets 
                outline: {   outline:           true,
                             outline_depth:     LEVEL },
                margin:  {   top:               SIZE,                     # default 10 (mm)

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -85,6 +85,7 @@ class WickedPdf
     generated_pdf_file.rewind
     generated_pdf_file.binmode
     pdf = generated_pdf_file.read
+    raise "Error generating PDF\n Command Error: #{err}" if options[:raise_on_all_errors] && !err.empty?
     raise "PDF could not be generated!\n Command Error: #{err}" if pdf && pdf.rstrip.empty?
     pdf
   rescue StandardError => e


### PR DESCRIPTION
Issue: When image assets fail to download from the web (return non 200 statuses).  We want to throw an exception.

Passing `extra: '--load-media-error-handling abort'` to WickedPdf should fail the pdf generation.  But it doesnt.  This seems to be because the underlying library `wkhtmltopdf` doesnt return the correct exit code it only returns error output.

Solution: enable a flag in wicked_pdf that will raise an exception if there is any output to stderr.
```
raise_on_all_errors: true
```