### PR TITLE
Updated spelling in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ class ThingsController < ApplicationController
                print_media_type:               true,
                disable_smart_shrinking:        true,
                use_xserver:                    true,
-               background:                     false,                     # backround needs to be true to enable background colors to render
+               background:                     false,                     # background needs to be true to enable background colors to render
                no_background:                  true,
                viewport_size:                  'TEXT',                    # available only with use_xserver or patched QT
                extra:                          '',                        # directly inserted into the command to wkhtmltopdf

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ If you would like to have WickedPdf automatically generate PDF views for all (or
 require 'wicked_pdf'
 config.middleware.use WickedPdf::Middleware
 ```
-If you want to turn on or off the middleware for certain urls, use the `:only` or `:except` conditions like so:
+If you want to turn on or off the middleware for certain URLs, use the `:only` or `:except` conditions like so:
 ```ruby
 # conditions can be plain strings or regular expressions, and you can supply only one or an array
 config.middleware.use WickedPdf::Middleware, {}, only: '/invoice'

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ However, the wicked_pdf_* helpers will use file:/// paths for assets when using 
 
 #### Gotchas
 
-If one image from your HTML cannot be found (relative or wrong path for ie), others images with right paths **may not** be displayed in the output PDF as well (it seems to be an issue with wkhtmltopdf).
+If one image from your HTML cannot be found (relative or wrong path for example), others images with right paths **may not** be displayed in the output PDF as well (it seems to be an issue with wkhtmltopdf).
 
 wkhtmltopdf may render at different resolutions on different platforms. For example, Linux prints at 75 dpi (native for WebKit) while on Windows it's at the desktop's DPI (which is normally 96 dpi). [Use `:zoom => 0.78125`](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2184) (75/96) to match Linux rendering to Windows.
 


### PR DESCRIPTION
I noticed the word "background" had been misspelt in the README, here is a PR fixing that. Also included are two other changes I noticed while reading through the file :) 