### PR TITLE
Defer including PdfHelper into ActionController::Base until it's loaded

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -9,7 +9,14 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :prepend, PdfHelper
+          hook = if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR <= 1
+                   :action_controller
+                 else
+                   :action_controller_base
+                 end
+          ActiveSupport.on_load(hook) do
+            ActionController::Base.send :prepend, PdfHelper
+          end
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -18,7 +25,9 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper
+          ActiveSupport.on_load(:action_controller) do
+            ActionController::Base.send :include, PdfHelper
+          end
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end
@@ -27,7 +36,9 @@ class WickedPdf
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper
+          ActiveSupport.on_load(:action_controller) do
+            ActionController::Base.send :include, PdfHelper
+          end
           if Rails::VERSION::MINOR > 0 && Rails.configuration.assets.enabled
             ActionView::Base.send :include, WickedPdfHelper::Assets
           else


### PR DESCRIPTION
ActionController::Base is lazily loaded by Rails and we don't want to prematurely load it, otherwise it may be loaded before initialization runs, then any configuration set in initialization is not copied over to ActionController::Base.

For example, the new Rails 5.2 config for `Rails.application.config.action_controller.default_protect_from_forgery` is assigned in an initializer, but ActionController::Base was loaded too early by the railtie, prior to running the initializers, so the value set was never set on ActionController::Base itself, thus never triggering the default protection.

Rails 3 is the first version where load hooks were introduced, and Rails 5.2 is the first version where an explicit hook for ActionController::Base was introduced.