### PR TITLE
Fix CI test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
 language:
   - ruby
+git:
+  depth: 1
+  quiet: true
 before_install:
   - sudo apt-get update -qq
-  - gem update bundler
+  - gem install bundler -v '< 2'
 bundler_args: --verbose
 sudo: required
-rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.0
-  - ruby-head
-gemfile:
-  - gemfiles/3.0.gemfile
-  - gemfiles/3.1.gemfile
-  - gemfiles/3.2.gemfile
 before_script:
   - bundle list
   - sudo apt-get install -y wkhtmltopdf
@@ -33,25 +24,40 @@ matrix:
         - gem update --system 1.8.25
         - gem --version
       gemfile: gemfiles/2.3.gemfile
-    - rvm: 2.0.0
-      gemfile: gemfiles/4.0.gemfile
-    - rvm: 2.2.0
-      gemfile: gemfiles/4.1.gemfile
-    - rvm: 2.2.0
-      gemfile: gemfiles/4.2.gemfile
-    - rvm: 2.3.0
-      gemfile: gemfiles/5.0.gemfile
-  allow_failures:
     - rvm: 1.9.2
       gemfile: gemfiles/3.0.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/3.1.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/3.2.gemfile
     - rvm: 1.9.3
+      gemfile: gemfiles/3.1.gemfile
+    - rvm: 2.0
+      gemfile: gemfiles/3.2.gemfile
+    - rvm: 2.0
       gemfile: gemfiles/4.0.gemfile
-    - rvm: 2.2.2
+    - rvm: 2.1
+      gemfile: gemfiles/4.1.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/4.2.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/5.0.gemfile
+      before_install:
+        # https://github.com/danmayer/coverband/issues/162
+        - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
+        - rvm @global do gem uninstall bundler -a -x -I || true
+        - gem install bundler -v '< 2'
+    - rvm: 2.4
+      gemfile: gemfiles/5.1.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/5.2.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/5.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/5.2.gemfile
+      before_install:
+        - gem install bundler -v '~> 2'
+    - rvm: ruby-head
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.3.0
+      before_install:
+        - gem install bundler -v '~> 2'
+  allow_failures:
+    - rvm: 2.6
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,13 @@ desc 'Generate dummy application for test cases'
 task :dummy_generate do
   Rake::Task[:dummy_remove].invoke
   puts 'Creating dummy application to run tests'
-  command = Rails::VERSION::MAJOR == 2 ? '' : 'new'
-  system("rails #{command} test/dummy")
+  if Rails::VERSION::MAJOR > 2
+    system('rails new test/dummy --database=sqlite3')
+  else
+    system('rails test/dummy')
+  end
   system('touch test/dummy/db/schema.rb')
+  FileUtils.cp 'test/fixtures/database.yml', 'test/dummy/config/'
   FileUtils.rm_r Dir.glob('test/dummy/test/*')
 end
 
@@ -45,7 +49,7 @@ task :dummy_remove do
   FileUtils.rm_r Dir.glob('test/dummy/*')
 end
 
-desc 'Generate documentation for the wicked_pdf plugin.'
+desc 'Generate documentation for the wicked_pdf gem.'
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = 'WickedPdf'

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem 'rdoc'
 gem 'rails', '~> 3.1.0'
-gem 'sqlite3'
 gem 'i18n', '~> 0.6.0'
 
 if RUBY_VERSION < '1.9.3'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rdoc'
+gem 'rails', '~> 5.1.0'
+
+gemspec path: '../'

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'rdoc'
+gem 'rails', '~> 5.2'
+gem 'sqlite3', '~> 1.3.6'
+gem 'bootsnap' # required to run `rake test` in Rails 5.2
+gem 'mocha', '= 1.3' # newer versions blow up
+
+gemspec path: '../'

--- a/test/fixtures/database.yml
+++ b/test/fixtures/database.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: sqlite3
+  database: ":memory:"
+  timeout: 500

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -32,7 +32,7 @@ DESC
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.50.0' if RUBY_VERSION >= '2.0.0'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Fix CI test suite

- Force bundler 1.x for most versions
- Add workaround for Ruby 2.3 bundler
- Fix sqlite3 issues
- Add new versions of Ruby and Rails