### PR TITLE
respect rails 5 `assigns` render option

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -79,7 +79,8 @@ class WickedPdf
         :template => options[:template],
         :layout => options[:layout],
         :formats => options[:formats],
-        :handlers => options[:handlers]
+        :handlers => options[:handlers],
+        :assigns => options[:assigns]
       }
       render_opts[:locals] = options[:locals] if options[:locals]
       render_opts[:file] = options[:file] if options[:file]
@@ -100,6 +101,7 @@ class WickedPdf
           :layout => options[:layout],
           :formats => options[:formats],
           :handlers => options[:handlers],
+          :assigns => options[:assigns],
           :content_type => 'text/html'
         }
         render_opts[:locals] = options[:locals] if options[:locals]
@@ -124,7 +126,8 @@ class WickedPdf
           :template => options[hf][:html][:template],
           :layout => options[hf][:html][:layout],
           :formats => options[hf][:html][:formats],
-          :handlers => options[hf][:html][:handlers]
+          :handlers => options[hf][:html][:handlers],
+          :assigns => options[hf][:html][:assigns]
         }
         render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
         render_opts[:file] = options[hf][:html][:file] if options[:file]


### PR DESCRIPTION
Rails 5 supports an `assigns` option to `render`/`render_to_string` that allows setting instance variables available to the template. This is particularly handy for rendering outside of controllers where these instance variables wouldn't otherwise be available.

It's a pass-through so I didn't add any new tests (but could.)