### PR TITLE
Add issue template.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,15 @@
+## Issue description
+
+## Expected or desired behavior
+
+## System specifications
+
+wicked_pdf gem version (output of `cat Gemfile.lock | grep wicked_pdf`):
+
+wkhtmltopdf version (output of `wkhtmltopdf --version`):
+
+whtmltopdf [provider gem](https://rubygems.org/search?utf8=%E2%9C%93&query=wkhtmltopdf) and version if one is used:
+
+platform/distribution and version (e.g. Windows 10 / Ubuntu 16.04 / Heroku cedar):
+
+


### PR DESCRIPTION
This should help with vague requests since a large number of issues that people have are related to specific versions of either `wkhtmltopdf`, a provider gem, or a Rails/sprockets/webpack asset rendering configuration issue.