### PR TITLE
Support render inline option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ class ThingsController < ApplicationController
         render pdf:                            'file_name',
                disposition:                    'attachment',                 # default 'inline'
                template:                       'things/show',
-               file:                           "#{Rails.root}/files/foo.erb"
+               file:                           "#{Rails.root}/files/foo.erb",
+               inline:                         '<!doctype html><html><head></head><body>INLINE HTML</body></html>',
                layout:                         'pdf',                        # for a pdf.pdf.erb file
                wkhtmltopdf:                    '/usr/local/bin/wkhtmltopdf', # path to binary
                show_as_html:                   params.key?('debug'),         # allow debugging based on url param

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -82,6 +82,7 @@ class WickedPdf
         :handlers => options[:handlers],
         :assigns => options[:assigns]
       }
+      render_opts[:inline] = options[:inline] if options[:inline]
       render_opts[:locals] = options[:locals] if options[:locals]
       render_opts[:file] = options[:file] if options[:file]
       html_string = render_to_string(render_opts)
@@ -104,6 +105,7 @@ class WickedPdf
           :assigns => options[:assigns],
           :content_type => 'text/html'
         }
+        render_opts[:inline] = options[:inline] if options[:inline]
         render_opts[:locals] = options[:locals] if options[:locals]
         render_opts[:file] = options[:file] if options[:file]
         render(render_opts)


### PR DESCRIPTION
It was discovered that we don't pass the `inline` option through to `render` in #797.

This PR adds support for this option when used with `render pdf: 'mypdf'`.