### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ git:
   quiet: true
 before_install:
   - sudo apt-get update -qq
-  - gem install bundler -v '< 2'
 bundler_args: --verbose
 sudo: required
 before_script:
@@ -51,8 +50,14 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.6
       gemfile: gemfiles/5.2.gemfile
+      before_install:
+        - gem update --system
+        - gem install bundler
     - rvm: 2.6
       gemfile: gemfiles/rails_edge.gemfile
+      before_install:
+        - gem update --system
+        - gem install bundler
     - rvm: ruby-head
       gemfile: gemfiles/5.2.gemfile
       before_install:

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -29,7 +29,7 @@ DESC
   spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rails'
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', RUBY_VERSION >= '2.5' ? '~> 2' : '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.50.0' if RUBY_VERSION >= '2.0.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'


### PR DESCRIPTION
5.2 started failing due to Bundler 1 and 2 differences.

This uses a variable dependency for the gem, and some overrides in the `.travis.yml` file.