### PR TITLE
Extract and encapsulate controller code

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -36,7 +36,8 @@ class WickedPdf
 
     def render_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        WickedPdf::Renderer.new(self).render(options)
+        @_pdf_renderer = WickedPdf::Renderer.new(self)
+        @_pdf_renderer.render(options)
       elsif respond_to?(:render_without_wicked_pdf)
         # support alias_method_chain (module included)
         render_without_wicked_pdf(options, *args, &block)
@@ -48,7 +49,8 @@ class WickedPdf
 
     def render_to_string_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        WickedPdf::Renderer.new(self).render_to_string(options)
+        @_pdf_renderer = WickedPdf::Renderer.new(self)
+        @_pdf_renderer.render_to_string(options)
       elsif respond_to?(:render_to_string_without_wicked_pdf)
         # support alias_method_chain (module included)
         render_to_string_without_wicked_pdf(options, *args, &block)
@@ -59,7 +61,12 @@ class WickedPdf
     end
 
     def prerender_header_and_footer(options)
-      WickedPdf::Renderer.new(self).prerender_header_and_footer(options)
+      @_pdf_renderer ||= WickedPdf::Renderer.new(self)
+      @_pdf_renderer.prerender_header_and_footer(options)
+    end
+
+    def clean_temp_files
+      @_pdf_renderer.clean_temp_files if @_pdf_renderer
     end
   end
 end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -36,8 +36,7 @@ class WickedPdf
 
     def render_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        options[:basic_auth] = set_basic_auth(options)
-        make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
+        WickedPdf::Renderer.new(self).render(options)
       elsif respond_to?(:render_without_wicked_pdf)
         # support alias_method_chain (module included)
         render_without_wicked_pdf(options, *args, &block)
@@ -49,9 +48,7 @@ class WickedPdf
 
     def render_to_string_with_wicked_pdf(options = nil, *args, &block)
       if options.is_a?(Hash) && options.key?(:pdf)
-        options[:basic_auth] = set_basic_auth(options)
-        options.delete :pdf
-        make_pdf((WickedPdf.config || {}).merge(options))
+        WickedPdf::Renderer.new(self).render_to_string(options)
       elsif respond_to?(:render_to_string_without_wicked_pdf)
         # support alias_method_chain (module included)
         render_to_string_without_wicked_pdf(options, *args, &block)
@@ -61,83 +58,8 @@ class WickedPdf
       end
     end
 
-    private
-
-    def set_basic_auth(options = {})
-      options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
-      return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
-      request.env['HTTP_AUTHORIZATION'].split(' ').last
-    end
-
-    def clean_temp_files
-      return unless defined?(@hf_tempfiles)
-      @hf_tempfiles.each(&:close!)
-    end
-
-    def make_pdf(options = {})
-      render_opts = {
-        :template => options[:template],
-        :layout => options[:layout],
-        :formats => options[:formats],
-        :handlers => options[:handlers],
-        :assigns => options[:assigns]
-      }
-      render_opts[:inline] = options[:inline] if options[:inline]
-      render_opts[:locals] = options[:locals] if options[:locals]
-      render_opts[:file] = options[:file] if options[:file]
-      html_string = render_to_string(render_opts)
-      options = prerender_header_and_footer(options)
-      w = WickedPdf.new(options[:wkhtmltopdf])
-      w.pdf_from_string(html_string, options)
-    end
-
-    def make_and_send_pdf(pdf_name, options = {})
-      options[:wkhtmltopdf] ||= nil
-      options[:layout] ||= false
-      options[:template] ||= File.join(controller_path, action_name)
-      options[:disposition] ||= 'inline'
-      if options[:show_as_html]
-        render_opts = {
-          :template => options[:template],
-          :layout => options[:layout],
-          :formats => options[:formats],
-          :handlers => options[:handlers],
-          :assigns => options[:assigns],
-          :content_type => 'text/html'
-        }
-        render_opts[:inline] = options[:inline] if options[:inline]
-        render_opts[:locals] = options[:locals] if options[:locals]
-        render_opts[:file] = options[:file] if options[:file]
-        render(render_opts)
-      else
-        pdf_content = make_pdf(options)
-        File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
-        send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
-      end
-    end
-
-    # Given an options hash, prerenders content for the header and footer sections
-    # to temp files and return a new options hash including the URLs to these files.
     def prerender_header_and_footer(options)
-      [:header, :footer].each do |hf|
-        next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
-        @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
-        options[hf][:html][:layout] ||= options[:layout]
-        render_opts = {
-          :template => options[hf][:html][:template],
-          :layout => options[hf][:html][:layout],
-          :formats => options[hf][:html][:formats],
-          :handlers => options[hf][:html][:handlers],
-          :assigns => options[hf][:html][:assigns]
-        }
-        render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
-        render_opts[:file] = options[hf][:html][:file] if options[:file]
-        tf.write render_to_string(render_opts)
-        tf.flush
-        options[hf][:html][:url] = "file:///#{tf.path}"
-      end
-      options
+      WickedPdf::Renderer.new(self).prerender_header_and_footer(options)
     end
   end
 end

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -1,4 +1,5 @@
 require 'wicked_pdf/pdf_helper'
+require 'wicked_pdf/renderer'
 require 'wicked_pdf/wicked_pdf_helper'
 require 'wicked_pdf/wicked_pdf_helper/assets'
 

--- a/lib/wicked_pdf/renderer.rb
+++ b/lib/wicked_pdf/renderer.rb
@@ -1,0 +1,108 @@
+class WickedPdf
+  class Renderer
+    attr_reader :controller
+
+    delegate :request, :send_data, :to => :controller
+
+    def initialize(controller)
+      @controller = controller
+      @hf_tempfiles = []
+    end
+
+    def render(options)
+      options[:basic_auth] = set_basic_auth(options)
+      make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
+    end
+
+    def render_to_string(options)
+      options[:basic_auth] = set_basic_auth(options)
+      options.delete :pdf
+      make_pdf((WickedPdf.config || {}).merge(options))
+    end
+
+    # Given an options hash, prerenders content for the header and footer sections
+    # to temp files and return a new options hash including the URLs to these files.
+    def prerender_header_and_footer(options)
+      [:header, :footer].each do |hf|
+        next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
+
+        options[hf][:html][:layout] ||= options[:layout]
+        render_opts = {
+          :template => options[hf][:html][:template],
+          :layout => options[hf][:html][:layout],
+          :formats => options[hf][:html][:formats],
+          :handlers => options[hf][:html][:handlers],
+          :assigns => options[hf][:html][:assigns]
+        }
+        render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
+        render_opts[:file] = options[hf][:html][:file] if options[:file]
+
+        path = render_tempfile("wicked_#{hf}_pdf.html", render_opts)
+        options[hf][:html][:url] = "file:///#{path}"
+      end
+      options
+    end
+
+    def clean_temp_files
+      @hf_tempfiles.each(&:close!)
+    end
+
+    private
+
+    def set_basic_auth(options = {})
+      options[:basic_auth] ||= WickedPdf.config.fetch(:basic_auth) { false }
+      return unless options[:basic_auth] && request.env['HTTP_AUTHORIZATION']
+      request.env['HTTP_AUTHORIZATION'].split(' ').last
+    end
+
+    def make_pdf(options = {})
+      render_opts = {
+        :template => options[:template],
+        :layout => options[:layout],
+        :formats => options[:formats],
+        :handlers => options[:handlers],
+        :assigns => options[:assigns]
+      }
+      render_opts[:inline] = options[:inline] if options[:inline]
+      render_opts[:locals] = options[:locals] if options[:locals]
+      render_opts[:file] = options[:file] if options[:file]
+      html_string = controller.render_to_string(render_opts)
+      options = prerender_header_and_footer(options)
+      w = WickedPdf.new(options[:wkhtmltopdf])
+      w.pdf_from_string(html_string, options)
+    end
+
+    def make_and_send_pdf(pdf_name, options = {})
+      options[:wkhtmltopdf] ||= nil
+      options[:layout] ||= false
+      options[:template] ||= File.join(controller_path, action_name)
+      options[:disposition] ||= 'inline'
+      if options[:show_as_html]
+        render_opts = {
+          :template => options[:template],
+          :layout => options[:layout],
+          :formats => options[:formats],
+          :handlers => options[:handlers],
+          :assigns => options[:assigns],
+          :content_type => 'text/html'
+        }
+        render_opts[:inline] = options[:inline] if options[:inline]
+        render_opts[:locals] = options[:locals] if options[:locals]
+        render_opts[:file] = options[:file] if options[:file]
+        render(render_opts)
+      else
+        pdf_content = make_pdf(options)
+        File.open(options[:save_to_file], 'wb') { |file| file << pdf_content } if options[:save_to_file]
+        send_data(pdf_content, :filename => pdf_name + '.pdf', :type => 'application/pdf', :disposition => options[:disposition]) unless options[:save_only]
+      end
+    end
+
+    def render_tempfile(filename, options)
+      tf = WickedPdfTempfile.new(filename)
+      @hf_tempfiles.push(tf)
+      tf.write controller.render_to_string(options)
+      tf.flush
+      tf.path
+    end
+  end
+end


### PR DESCRIPTION
I'm having some issues with the latest release v1.2.0. In diagnosing I read through the gem code and saw quite a bit of method pollution in the base controller I'd like to get rid of. 

I've extract the controller code from PdfHelper into a renderer class to encapsulate it. This helps remove method pollution and gives more freedom to refactor.

This PR is first of probably a few PRs to help minimise impact on base controller render path.