### PR TITLE
Use module#prepend when available.

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -5,20 +5,16 @@ require 'wicked_pdf/wicked_pdf_helper/assets'
 class WickedPdf
   if defined?(Rails.env)
 
-    if Rails::VERSION::MAJOR >= 5
+    if Rails::VERSION::MAJOR >= 4
 
       class WickedRailtie < Rails::Railtie
         initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :prepend, PdfHelper
-          ActionView::Base.send :include, WickedPdfHelper::Assets
-        end
-      end
-
-    elsif Rails::VERSION::MAJOR == 4
-
-      class WickedRailtie < Rails::Railtie
-        initializer 'wicked_pdf.register' do |_app|
-          ActionController::Base.send :include, PdfHelper
+          if ActionController::Base.respond_to?(:prepend) &&
+             Object.method(:new).respond_to?(:super_method)
+            ActionController::Base.send :prepend, PdfHelper
+          else
+            ActionController::Base.send :include, PdfHelper
+          end
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end


### PR DESCRIPTION
In #810 It was discovered that version `1.2.0` was released with an issue that would result in a `SystemStackError (stack level too deep)`.

I believe this has to do with the usage of `alias_method_chain` applied to `ActionController::Base#render`, which may also be tampered with by something else in the `Gemfile`.