### PR TITLE
Adjust gemspec development dependencies

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -29,7 +29,7 @@ DESC
   spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rails'
-  spec.add_development_dependency 'bundler', RUBY_VERSION >= '2.5' ? '~> 2' : '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.13', '<= 2'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.50.0' if RUBY_VERSION >= '2.0.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -35,4 +35,5 @@ DESC
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'test-unit'
+  spec.add_development_dependency 'bootsnap'
 end

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -29,7 +29,7 @@ DESC
   spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rails'
-  spec.add_development_dependency 'bundler', '>= 1.13', '<= 2'
+  spec.add_development_dependency 'bundler', '>= 1.13', '< 3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.50.0' if RUBY_VERSION >= '2.0.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3.6'


### PR DESCRIPTION
When running the tests for local dev for the first time I ran into a few issues. 

Firstly the bundler version in Ruby >= 2.5 was pegged to bundler >= 2. I don't think this necessary as I am happily continuing to use bundler v1.17.x for the moment and didn't want to be forced to upgrade. So I have relaxed the bundler version to use what is currently installed since there is no dependency on v2 in the core code.

Also added bootsnap since the dummy app requires it when booting.

