### PR TITLE
Encapsulate binary path and version handling

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -42,6 +42,10 @@ class WickedPdf
     @binary = Binary.new(wkhtmltopdf_binary_path, DEFAULT_BINARY_VERSION)
   end
 
+  def binary_version
+    @binary.version
+  end
+
   def pdf_from_html_file(filepath, options = {})
     pdf_from_url("file:///#{filepath}", options)
   end
@@ -95,10 +99,6 @@ class WickedPdf
   end
 
   private
-
-  def binary_version
-    @binary.version
-  end
 
   def in_development_mode?
     return Rails.env == 'development' if defined?(Rails.env)

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -42,10 +42,6 @@ class WickedPdf
     @binary = Binary.new(wkhtmltopdf_binary_path, DEFAULT_BINARY_VERSION)
   end
 
-  def binary_version
-    @binary.version
-  end
-
   def pdf_from_html_file(filepath, options = {})
     pdf_from_url("file:///#{filepath}", options)
   end
@@ -99,6 +95,10 @@ class WickedPdf
   end
 
   private
+
+  def binary_version
+    @binary.version
+  end
 
   def in_development_mode?
     return Rails.env == 'development' if defined?(Rails.env)

--- a/lib/wicked_pdf/binary.rb
+++ b/lib/wicked_pdf/binary.rb
@@ -1,0 +1,52 @@
+class WickedPdf
+  class Binary
+    EXE_NAME = 'wkhtmltopdf'.freeze
+
+    attr_reader :path, :default_version
+
+    def initialize(binary_path, default_version = WickedPdf::DEFAULT_BINARY_VERSION)
+      @path = binary_path || find_binary_path
+      @default_version = default_version
+
+      raise "Location of #{EXE_NAME} unknown" if @path.empty?
+      raise "Bad #{EXE_NAME}'s path: #{@path}" unless File.exist?(@path)
+      raise "#{EXE_NAME} is not executable" unless File.executable?(@path)
+    end
+
+    def version
+      @version ||= retrieve_binary_version
+    end
+
+    def parse_version_string(version_info)
+      match_data = /wkhtmltopdf\s*(\d*\.\d*\.\d*\w*)/.match(version_info)
+      if match_data && (match_data.length == 2)
+        Gem::Version.new(match_data[1])
+      else
+        default_version
+      end
+    end
+
+    private
+
+    def retrieve_binary_version
+      _stdin, stdout, _stderr = Open3.popen3(@path + ' -V')
+      parse_version_string(stdout.gets(nil))
+    rescue StandardError
+      default_version
+    end
+
+    def find_binary_path
+      possible_locations = (ENV['PATH'].split(':') + %w[/usr/bin /usr/local/bin]).uniq
+      possible_locations += %w[~/bin] if ENV.key?('HOME')
+      exe_path ||= WickedPdf.config[:exe_path] unless WickedPdf.config.empty?
+      exe_path ||= begin
+        detected_path = (defined?(Bundler) ? Bundler.which('wkhtmltopdf') : `which wkhtmltopdf`).chomp
+        detected_path.present? && detected_path
+      rescue StandardError
+        nil
+      end
+      exe_path ||= possible_locations.map { |l| File.expand_path("#{l}/#{EXE_NAME}") }.find { |location| File.exist?(location) }
+      exe_path || ''
+    end
+  end
+end

--- a/test/unit/wicked_pdf_binary_test.rb
+++ b/test/unit/wicked_pdf_binary_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class WickedPdfBinaryTest < ActiveSupport::TestCase
+  test 'should extract old wkhtmltopdf version' do
+    version_info_sample = "Name:\n  wkhtmltopdf 0.9.9\n\nLicense:\n  Copyright (C) 2008,2009 Wkhtmltopdf Authors.\n\n\n\n  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\n  This is free software: you are free to change and redistribute it. There is NO\n  WARRANTY, to the extent permitted by law.\n\nAuthors:\n  Written by Jakob Truelsen. Patches by Mrio Silva, Benoit Garret and Emmanuel\n  Bouthenot.\n"
+    assert_equal WickedPdf::DEFAULT_BINARY_VERSION, binary.parse_version_string(version_info_sample)
+  end
+
+  test 'should extract new wkhtmltopdf version' do
+    version_info_sample = "Name:\n  wkhtmltopdf 0.11.0 rc2\n\nLicense:\n  Copyright (C) 2010 wkhtmltopdf/wkhtmltoimage Authors.\n\n\n\n  License LGPLv3+: GNU Lesser General Public License version 3 or later\n  <http://gnu.org/licenses/lgpl.html>. This is free software: you are free to\n  change and redistribute it. There is NO WARRANTY, to the extent permitted by\n  law.\n\nAuthors:\n  Written by Jan Habermann, Christian Sciberras and Jakob Truelsen. Patches by\n  Mehdi Abbad, Lyes Amazouz, Pascal Bach, Emmanuel Bouthenot, Benoit Garret and\n  Mario Silva."
+    assert_equal Gem::Version.new('0.11.0'), binary.parse_version_string(version_info_sample)
+  end
+
+  test 'should extract wkhtmltopdf version with nondigit symbols' do
+    version_info_sample = "Name:\n  wkhtmltopdf 0.10.4b\n\nLicense:\n  Copyright (C) 2008,2009 Wkhtmltopdf Authors.\n\n\n\n  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\n  This is free software: you are free to change and redistribute it. There is NO\n  WARRANTY, to the extent permitted by law.\n\nAuthors:\n  Written by Jakob Truelsen. Patches by Mrio Silva, Benoit Garret and Emmanuel\n  Bouthenot.\n"
+    assert_equal Gem::Version.new('0.10.4b'), binary.parse_version_string(version_info_sample)
+  end
+
+  test 'should fallback to default version on parse error' do
+    assert_equal WickedPdf::DEFAULT_BINARY_VERSION, binary.parse_version_string('')
+  end
+
+  def binary(path = nil)
+    WickedPdf::Binary.new(path)
+  end
+end

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -6,9 +6,7 @@ HTML_DOCUMENT = '<html><body>Hello World</body></html>'.freeze
 # Also, smash the returned array of options into a single string for
 # convenience in testing below.
 class WickedPdf
-  undef :binary_version
-  undef :binary_version=
-  attr_accessor :binary_version
+  attr_accessor :binary
 
   def get_parsed_options(opts)
     parse_options(opts).join(' ')
@@ -181,31 +179,8 @@ class WickedPdfTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should extract old wkhtmltopdf version' do
-    version_info_sample = "Name:\n  wkhtmltopdf 0.9.9\n\nLicense:\n  Copyright (C) 2008,2009 Wkhtmltopdf Authors.\n\n\n\n  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\n  This is free software: you are free to change and redistribute it. There is NO\n  WARRANTY, to the extent permitted by law.\n\nAuthors:\n  Written by Jakob Truelsen. Patches by Mrio Silva, Benoit Garret and Emmanuel\n  Bouthenot.\n"
-    assert_equal WickedPdf::DEFAULT_BINARY_VERSION, @wp.send(:parse_version, version_info_sample)
-  end
-
-  test 'should extract new wkhtmltopdf version' do
-    version_info_sample = "Name:\n  wkhtmltopdf 0.11.0 rc2\n\nLicense:\n  Copyright (C) 2010 wkhtmltopdf/wkhtmltoimage Authors.\n\n\n\n  License LGPLv3+: GNU Lesser General Public License version 3 or later\n  <http://gnu.org/licenses/lgpl.html>. This is free software: you are free to\n  change and redistribute it. There is NO WARRANTY, to the extent permitted by\n  law.\n\nAuthors:\n  Written by Jan Habermann, Christian Sciberras and Jakob Truelsen. Patches by\n  Mehdi Abbad, Lyes Amazouz, Pascal Bach, Emmanuel Bouthenot, Benoit Garret and\n  Mario Silva."
-    assert_equal Gem::Version.new('0.11.0'), @wp.send(:parse_version, version_info_sample)
-  end
-
-  test 'should extract wkhtmltopdf version with nondigit symbols' do
-    version_info_sample = "Name:\n  wkhtmltopdf 0.10.4b\n\nLicense:\n  Copyright (C) 2008,2009 Wkhtmltopdf Authors.\n\n\n\n  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.\n  This is free software: you are free to change and redistribute it. There is NO\n  WARRANTY, to the extent permitted by law.\n\nAuthors:\n  Written by Jakob Truelsen. Patches by Mrio Silva, Benoit Garret and Emmanuel\n  Bouthenot.\n"
-    assert_equal Gem::Version.new('0.10.4b'), @wp.send(:parse_version, version_info_sample)
-  end
-
-  test 'should fallback to default version on parse error' do
-    assert_equal WickedPdf::DEFAULT_BINARY_VERSION, @wp.send(:parse_version, '')
-  end
-
-  test 'should set version on initialize' do
-    assert_not_equal @wp.send(:binary_version), ''
-  end
-
   test 'should not use double dash options for version without dashes' do
-    @wp.binary_version = WickedPdf::BINARY_VERSION_WITHOUT_DASHES
+    @wp.binary = Struct.new(:version).new(WickedPdf::BINARY_VERSION_WITHOUT_DASHES)
 
     %w[toc cover].each do |name|
       assert_equal @wp.get_valid_option(name), name
@@ -213,7 +188,7 @@ class WickedPdfTest < ActiveSupport::TestCase
   end
 
   test 'should use double dash options for version with dashes' do
-    @wp.binary_version = Gem::Version.new('0.11.0')
+    @wp.binary = Struct.new(:version).new(Gem::Version.new('0.11.0'))
 
     %w[toc cover].each do |name|
       assert_equal @wp.get_valid_option(name), "--#{name}"


### PR DESCRIPTION
Cleans up main class and allows refactoring of path handling.

Binary path discovery can be complex it seems and this offers a path to improved handling or overriding if necessary. 

Long term goal of combining extracted option parsing and this to allow a command class to combine and execute and return result.

I think these combined PRs provide a path to a well factored and a cleaner handling gem's functions.