### PR TITLE
Avoid conflict with remotipart.

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -8,7 +8,7 @@ class WickedPdf
     if Rails::VERSION::MAJOR >= 4
 
       class WickedRailtie < Rails::Railtie
-        initializer 'wicked_pdf.register' do |_app|
+        initializer 'wicked_pdf.register', :after => 'remotipart.controller_helper' do |_app|
           if ActionController::Base.respond_to?(:prepend) &&
              Object.method(:new).respond_to?(:super_method)
             ActionController::Base.send :prepend, PdfHelper


### PR DESCRIPTION
If remotipart is loaded after wicked_pdf, it's aliasing of `render`
causes it to call render in an endless loop causing a SystemStackError.

This forces the WickedPdf railtie to initialize only after remotipart
has already aliased `render`, so that when we call render, it's the
remotipart alias.