### PR TITLE
Add note about options based on wkhtmltopdf version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ In this case, you can use that standard Rails helpers and point to the current C
 ```
 
 ### Advanced Usage with all available options
+
+_NOTE: Certain options are only supported in specific versions of wkhtmltopdf._
+
 ```ruby
 class ThingsController < ApplicationController
   def show


### PR DESCRIPTION
I would much prefer to label each option with the version of wkhtmltopdf that is required to use it, and possibly commands for older or newer versions, but I don't have to time to verify that and will be more difficult to maintain. Ultimately, the source of truth should be the wkhtmltopdf docs of your specific version. But this note at least warns the user about this requirement.

Fixes #478.