### PR TITLE
Add support for --log-level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ class ThingsController < ApplicationController
                viewport_size:                  'TEXT',                    # available only with use_xserver or patched QT
                extra:                          '',                        # directly inserted into the command to wkhtmltopdf
                raise_on_all_errors:            nil,                       # raise error for any stderr output.  Such as missing media, image assets
+               log_level:                      'none, error, warn, info',
                outline: {   outline:           true,
                             outline_depth:     LEVEL },
                margin:  {   top:               SIZE,                     # default 10 (mm)

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -293,7 +293,8 @@ class WickedPdf
                                   :dpi,
                                   :page_size,
                                   :page_width,
-                                  :title])
+                                  :title,
+                                  :log_level])
       r += make_options(options, [:lowquality,
                                   :grayscale,
                                   :no_pdf_compression], '', :boolean)

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -297,7 +297,8 @@ class WickedPdf
                                   :log_level])
       r += make_options(options, [:lowquality,
                                   :grayscale,
-                                  :no_pdf_compression], '', :boolean)
+                                  :no_pdf_compression,
+                                  :quiet], '', :boolean)
       r += make_options(options, [:image_dpi,
                                   :image_quality,
                                   :page_height], '', :numeric)


### PR DESCRIPTION
Without the ability to override it, `--log-level info` is implied when `wkhtmltopdf` executes. This - for some unholy reason - sends progress messages to stderr, which has the unfortunate side-effect of making WickedPdf panic dramatically over successfully completed tasks when run with `raise_on_all_errors: true`.

The intent of the changes herein is to ensure sensible behavior when running with `log_level: 'error', raise_on_all_errors: true`.