### PR TITLE
Fix Webpacker helpers in production env

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -126,7 +126,8 @@ class WickedPdf
       end
 
       def precompiled_or_absolute_asset?(source)
-        Rails.configuration.assets.compile == false ||
+        !Rails.configuration.respond_to?(:assets) ||
+          Rails.configuration.assets.compile == false ||
           source.to_s[0] == '/' ||
           source.to_s.match(/\Ahttps?\:\/\//)
       end


### PR DESCRIPTION
`Rails.configuration.assets` will be undefined if asset pipeline is not being used, which leads to an error why trying to check the value of `assets.compile`.

This is primarily a problem when using the webpacker helpers (b/c no sprockets) and only in non-dev environments (b/c this logic gets short-circuited if there's a webpack dev server running.)

`Rails.configuration.assets` is referred to in one other place but it's a block that's only run in Rails 3 so presumably doesn't need to be updated.