### PR TITLE
Add rubygems metadata hash into the gemspec file

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
     In other words, rather than dealing with a PDF generation DSL of some sort,
     you simply write an HTML view as you would normally, and let Wicked take care of the hard stuff.
 DESC
+  spec.metadata =    {
+    'changelog_uri' => 'https://github.com/mileszs/wicked_pdf/blob/master/CHANGELOG.md'
+  }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Hi guys
This PR is linked to the issue [#855](https://github.com/mileszs/wicked_pdf/issues/855)
The idea is to add the metadata hash into the gemspec file so the changelog_uri is listed as a changelog link in the side panel on RubyGems.org website.
I hope it's all good.
Tks
Leandro.