### PR TITLE
False-positive

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -77,7 +77,7 @@ class WickedPdf
     generated_pdf_file.rewind
     generated_pdf_file.binmode
     pdf = generated_pdf_file.read
-    raise "Error generating PDF\n Command Error: #{err}" if options[:raise_on_all_errors] && !err.empty?
+    raise "Error generating PDF\n Command Error: #{err}" if options[:raise_on_all_errors] && !err.empty? && !err.strip.ends_with?('Done')
     raise "PDF could not be generated!\n Command Error: #{err}" if pdf && pdf.rstrip.empty?
     pdf
   rescue StandardError => e


### PR DESCRIPTION
@unixmonkey @mileszs With the option: `raise_on_all_errors: true`, even if pdf is generated successfully, is throwed an exception, because `err` contains the progress of process, with "Done" in the end 👍 