### PR TITLE
Support for rails 6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.2
   Exclude:
+    - 'gemfiles/bin/*'
     - 'test/dummy/**/*'
 
 Metrics/BlockLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,7 @@ Bundler/OrderedGems:
     - 'gemfiles/5.0.gemfile'
     - 'gemfiles/5.1.gemfile'
     - 'gemfiles/5.2.gemfile'
+    - 'gemfiles/6.0.gemfile'
     - 'gemfiles/rails_edge.gemfile'
 
 # Offense count: 2
@@ -140,6 +141,7 @@ Style/HashSyntax:
     - 'gemfiles/5.0.gemfile'
     - 'gemfiles/5.1.gemfile'
     - 'gemfiles/5.2.gemfile'
+    - 'gemfiles/6.0.gemfile'
     - 'gemfiles/rails_edge.gemfile'
 
 # Offense count: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,11 @@ matrix:
         - gem update --system
         - gem install bundler
     - rvm: 2.6
+      gemfile: gemfiles/6.0.gemfile
+      before_install:
+        - gem update --system
+        - gem install bundler
+    - rvm: 2.6
       gemfile: gemfiles/rails_edge.gemfile
       before_install:
         - gem update --system

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,12 @@ task :dummy_generate do
   system('touch test/dummy/db/schema.rb')
   FileUtils.cp 'test/fixtures/database.yml', 'test/dummy/config/'
   FileUtils.rm_r Dir.glob('test/dummy/test/*')
+
+  # rails 6 needs this to be present before start:
+  FileUtils.mkdir_p('test/dummy/app/assets/config')
+  FileUtils.mkdir_p('test/dummy/app/assets/javascripts')
+  FileUtils.cp 'test/fixtures/manifest.js', 'test/dummy/app/assets/config/'
+  FileUtils.cp 'test/fixtures/wicked.js', 'test/dummy/app/assets/javascripts/'
 end
 
 desc 'Remove dummy application'

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem 'rdoc'
 gem 'rails', '~> 4.0.0'
+gem 'sqlite3', '~> 1.3.6'
 
 gemspec path: '../'

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -2,5 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rdoc'
 gem 'rails', '~> 4.1.0'
+gem 'sqlite3', '~> 1.3.6'
 
 gemspec path: '../'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rdoc'
+gem 'bundler', '~>1.3'
+gem 'sqlite3', '~> 1.3.6'
+gem 'sprockets', '~>3.0'
 gem 'rails', '~> 4.2.0'
 
 gemspec path: '../'

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rdoc'
+gem 'sqlite3', '~> 1.3.6'
+gem 'sprockets', '~>3.0' # v4 strips newlines from assets causing tests to fail
 gem 'rails', '~> 5.0.0'
 
 gemspec path: '../'

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rdoc'
+gem 'sqlite3', '~> 1.3.6'
+gem 'sprockets', '~>3.0' # v4 strips newlines from assets causing tests to fail
 gem 'rails', '~> 5.1.0'
 
 gemspec path: '../'

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'rdoc'
 gem 'rails', '~> 5.2'
 gem 'sqlite3', '~> 1.3.6'
+gem 'sprockets', '~>3.0' # v4 strips newlines from assets causing tests to fail
 gem 'bootsnap' # required to run `rake test` in Rails 5.2
 gem 'mocha', '= 1.3' # newer versions blow up
 

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
+gem 'bundler', '~>2'
 gem 'rdoc'
-gem 'rails', git:  'https://github.com/rails/rails.git'
+gem 'rails', '~>6.0.1'
 gem 'sqlite3', '~> 1.4'
+gem 'sprockets', '~>3.0'
 gem 'bootsnap' # required to run `rake test` in Rails 6.0
 gem 'mocha', '= 1.3' # newer versions blow up
 

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -6,13 +6,15 @@ class WickedPdf
   if defined?(Rails.env)
     class WickedRailtie < Rails::Railtie
       initializer 'wicked_pdf.register', :after => 'remotipart.controller_helper' do |_app|
-        if ActionController::Base.respond_to?(:prepend) &&
-           Object.method(:new).respond_to?(:super_method)
-          ActionController::Base.send :prepend, PdfHelper
-        else
-          ActionController::Base.send :include, PdfHelper
+        ActiveSupport.on_load(:action_controller) do
+          if ActionController::Base.respond_to?(:prepend) &&
+             Object.method(:new).respond_to?(:super_method)
+            ActionController::Base.send :prepend, PdfHelper
+          else
+            ActionController::Base.send :include, PdfHelper
+          end
+          ActionView::Base.send :include, WickedPdfHelper::Assets
         end
-        ActionView::Base.send :include, WickedPdfHelper::Assets
       end
     end
 

--- a/test/fixtures/manifest.js
+++ b/test/fixtures/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link wicked.js
+//= link wicked.css

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,15 @@ if (assets_dir = Rails.root.join('app/assets')) && File.directory?(assets_dir)
   File.open(destination, 'w') { |f| f.write(source) }
 
   # Copy JS file
-  destination = assets_dir.join('javascripts/wicked.js')
+  js_dir = assets_dir.join('javascripts')
+  Dir.mkdir(js_dir) unless File.directory?(js_dir)
+  destination = js_dir.join('wicked.js')
   source = File.read('test/fixtures/wicked.js')
+  File.open(destination, 'w') { |f| f.write(source) }
+
+  config_dir = assets_dir.join('config')
+  Dir.mkdir(config_dir) unless File.directory?(config_dir)
+  source = File.read('test/fixtures/manifest.js')
+  destination = config_dir.join('manifest.js')
   File.open(destination, 'w') { |f| f.write(source) }
 end

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -33,10 +33,10 @@ DESC
   spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rails'
-  spec.add_development_dependency 'bundler', RUBY_VERSION >= '2.5' ? '~> 2' : '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop', '~> 0.68.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
+  spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
In rails 6 wicked_pdf initializer causes 
> DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.
>
> Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.
> ...

because of early access to `ActionController::Base` and can be fixed by lazy loading.

This PR fixes it by using `ActiveSupport.on_load` (supported since rails 3) 

Also made tests pass on ruby 2.6 and fresh gem versions (had to lock sprockets to 3 because of changed newline handling)