### PR TITLE
Added option to skip the prefix of temp files with file:///

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -46,7 +46,8 @@ class WickedPdf
     string_file.write(string)
     string_file.close
 
-    pdf = pdf_from_html_file(string_file.path, options)
+    action = options[:skip_file_prefix] ? 'pdf_from_url' : 'pdf_from_html_file'
+    pdf = send(action, string_file.path, options)
     pdf
   ensure
     string_file.close! if string_file

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -135,7 +135,7 @@ class WickedPdf
         render_opts[:file] = options[hf][:html][:file] if options[:file]
         tf.write render_to_string(render_opts)
         tf.flush
-        options[hf][:html][:url] = "file:///#{tf.path}"
+        options[hf][:html][:url] = options[:skip_file_prefix] ? tf.path : "file:///#{tf.path}"
       end
       options
     end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -122,7 +122,7 @@ class WickedPdf
       [:header, :footer].each do |hf|
         next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
         @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html", options[:temp_path]))
         options[hf][:html][:layout] ||= options[:layout]
         render_opts = {
           :template => options[hf][:html][:template],


### PR DESCRIPTION
Made two changes:

1/ Added option `option[:slip_file_prefix]` that prevents `pdf_from_string` from calling .`pdf_from_html_file` and calls `pdf_from_url` directly.
2/ This option also influences the temp file that is created for header/footer content
3/ Passed the `options[:temp_path]` to the Tempfile that is being created for the header/footer content.