### PR TITLE
Force UTF-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixes
 - None
 
+## [2.0.2] - 2020-03-17
+### Fixes
+- Force UTF-8 encoding in assets helper
+
 ## [2.0.1] - 2020-02-22
 ### Fixes
 - [Replace open-uri with more secure Net:HTTP.get](https://github.com/mileszs/wicked_pdf/pull/864)

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -147,6 +147,7 @@ class WickedPdf
 
       def read_from_uri(uri)
         asset = Net::HTTP.get(URI(uri))
+        asset.force_encoding('UTF-8') if asset
         asset = gzip(asset) if WickedPdf.config[:expect_gzipped_remote_assets]
         asset
       end


### PR DESCRIPTION
Added force encoding to UTF-8 to fix rendering of PDFs with UTF characters.

Fixes #893 