### PR TITLE
Support webpacker assets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ Metrics/BlockLength:
   Exclude:
     - 'wicked_pdf.gemspec'
 
+Metrics/ModuleLength:
+  Exclude:
+    # Excluding to keep the logic in one module for the time being.
+    - 'lib/wicked_pdf/wicked_pdf_helper/assets.rb'
+
 # I'd like wicked_pdf to keep Ruby 1.8 compatibility for now
 Style/HashSyntax:
   EnforcedStyle: hash_rockets

--- a/README.md
+++ b/README.md
@@ -109,10 +109,12 @@ Using wicked_pdf_helpers with asset pipeline raises `Asset names passed to helpe
 
 #### Webpacker usage
 
-wicked_pdf supports webpack stylesheets and javascript assets.
+wicked_pdf supports webpack assets.
 
 Use `wicked_pdf_stylesheet_pack_tag` for stylesheets
 Use `wicked_pdf_javascript_pack_tag` for javascripts
+
+Use `wicked_pdf_asset_pack_path` to access an asset directly, for example: `image_tag wicked_pdf_asset_pack_path("media/images/foobar.png")`
 
 #### Asset pipeline usage
 

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -79,6 +79,16 @@ class WickedPdf
         end
       end
 
+      def wicked_pdf_asset_pack_path(asset)
+        return unless defined?(Webpacker)
+
+        if running_in_development?
+          asset_pack_path(asset)
+        else
+          wicked_pdf_asset_path webpacker_source_url(asset)
+        end
+      end
+
       private
 
       # borrowed from actionpack/lib/action_view/helpers/asset_url_helper.rb


### PR DESCRIPTION
Introduces a helper method to access webpacked assets directly.

e.g:

`image_tag wicked_pdf_asset_pack_path("media/images/foobar.png")`