### PR TITLE
Support for --disable-local-file-access to stop SSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ class ThingsController < ApplicationController
                disable_external_links:         true,
                print_media_type:               true,
                disable_smart_shrinking:        true,
+               disable_local_file_access:      true,
                use_xserver:                    true,
                background:                     false,                     # background needs to be true to enable background colors to render
                no_background:                  true,

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -317,6 +317,7 @@ class WickedPdf
                                   :disable_external_links,
                                   :print_media_type,
                                   :disable_smart_shrinking,
+                                  :disable_local_file_access,
                                   :use_xserver,
                                   :no_background,
                                   :images,

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -175,7 +175,8 @@ class WickedPdfTest < ActiveSupport::TestCase
     [
       :book, :default_header, :disable_javascript, :grayscale, :lowquality,
       :enable_plugins, :disable_internal_links, :disable_external_links,
-      :print_media_type, :disable_smart_shrinking, :use_xserver, :no_background
+      :print_media_type, :disable_smart_shrinking, :disable_local_file_access,
+      :use_xserver, :no_background
     ].each do |o|
       assert_equal "--#{o.to_s.tr('_', '-')}", @wp.get_parsed_options(o => true).strip
     end


### PR DESCRIPTION
- When we are depended on taking HTML as an input from the user, they can add malicious content, and fetch any system file by doing something like:
```
"><iframe src="http://SOME_IP/latest/meta-data/public-keys/0/openssh-key" height="500" width="500">
``` 

- This can be fixed by passing ```--disable-local-file-access``` to **wkhtmltopdf**