### PR TITLE
Add option `use_xvfb` to emulate an X server

### DIFF
--- a/generators/wicked_pdf/templates/wicked_pdf.rb
+++ b/generators/wicked_pdf/templates/wicked_pdf.rb
@@ -18,4 +18,10 @@ WickedPdf.config = {
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
   # layout: 'pdf.html',
+
+  # Using wkhtmltopdf without an X server can be achieved by enabling the
+  # 'use_xvfb' flag. This will wrap all wkhtmltopdf commands around the
+  # 'xvfb-run' command, in order to simulate an X server.
+  #
+  # use_xvfb: true,
 }

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -57,6 +57,7 @@ class WickedPdf
     options.merge!(WickedPdf.config) { |_key, option, _config| option }
     generated_pdf_file = WickedPdfTempfile.new('wicked_pdf_generated_file.pdf', options[:temp_path])
     command = [@exe_path]
+    command.unshift(find_xvfb_run_binary_path) if options[:use_xvfb]
     command += parse_options(options)
     command << url
     command << generated_pdf_file.path.to_s
@@ -326,9 +327,13 @@ class WickedPdf
     r
   end
 
-  def find_wkhtmltopdf_binary_path
+  def possible_binary_locations
     possible_locations = (ENV['PATH'].split(':') + %w[/usr/bin /usr/local/bin]).uniq
     possible_locations += %w[~/bin] if ENV.key?('HOME')
+  end
+
+  def find_wkhtmltopdf_binary_path
+    possible_locations = possible_binary_locations
     exe_path ||= WickedPdf.config[:exe_path] unless WickedPdf.config.empty?
     exe_path ||= begin
       detected_path = (defined?(Bundler) ? Bundler.which('wkhtmltopdf') : `which wkhtmltopdf`).chomp
@@ -338,5 +343,12 @@ class WickedPdf
     end
     exe_path ||= possible_locations.map { |l| File.expand_path("#{l}/#{EXE_NAME}") }.find { |location| File.exist?(location) }
     exe_path || ''
+  end
+
+  def find_xvfb_run_binary_path
+    possible_locations = possible_binary_locations
+    path = possible_locations.map { |l| File.expand_path("#{l}/xvfb-run") }.find { |location| File.exist?(location) }
+    raise StandardError.new('Could not find binary xvfb-run on the system.') unless path
+    path
   end
 end


### PR DESCRIPTION
Hi,

so I really struggled to get `wkhtmltopdf` (which is obviously used by `wicked_pdf`) working without having an X server running on my virtual server. Unfortunately, the best solution I found, was to wrap all `wkhtmltopdf` around the `xvfb-run` command which is - from my understanding - emulating an X server for systems where a real X server is not available. Doing so, made my PDF's generating normally again.

I'm not really sure whether there's any better solution. I didn't find anything working so far besides the approach I'm following.

As there are many topics/issues about generating PDF's without an X server being available, I decided to propose my code changes to `wicked_pdf`. Let's discuss whether this is a good approach or if you see anything else, which seems to be more suitable.

____
Commit Message:

On some systems an X server is not available, and thus a PDF generation
is not possible. This can be avoided when installing `xvfb-run` which
emulates an X server.

Enabling the `use_xvfb` option will wrap any `wkhtmltopdf` commands
around the command `xvfb-run`, in order to be able to create PDF's, even
without having an X server running.