### PR TITLE
[DOC] add 'locals' option to the README advanced section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ class ThingsController < ApplicationController
         render pdf:                            'file_name',
                disposition:                    'attachment',                 # default 'inline'
                template:                       'things/show',
+               locals:                         {foo: @bar},
                file:                           "#{Rails.root}/files/foo.erb",
                inline:                         '<!doctype html><html><head></head><body>INLINE HTML</body></html>',
                layout:                         'pdf',                        # for a pdf.pdf.erb file


### PR DESCRIPTION
I was looking for this options, I find it strange to have it for the `header` and `footer` options, but not the main one... Digging into the code reveals that it actually exists.

So I suggest adding it in the README.

Thanks for this nice gem!