### PR TITLE
Add a option to disable/enable local file access, that is enabled by default in 0.12.5 and false by default in 0.12.6 version of wkhtmltopdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ class ThingsController < ApplicationController
                print_media_type:               true,
 
                # define as true the key 'disable_local_file_access' or 'enable_local_file_access', not both
-               disable_local_file_access:      false,
-               enable_local_file_access:       true,
+               disable_local_file_access:      true,
+               enable_local_file_access:       false,
 
                disable_smart_shrinking:        true,
                use_xserver:                    true,

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ class ThingsController < ApplicationController
                disable_internal_links:         true,
                disable_external_links:         true,
                print_media_type:               true,
+
+               # define as true the key 'disable_local_file_access' or 'enable_local_file_access', not both
+               disable_local_file_access:      false,
+               enable_local_file_access:       true,
+
                disable_smart_shrinking:        true,
                use_xserver:                    true,
                background:                     false,                     # background needs to be true to enable background colors to render

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -316,6 +316,7 @@ class WickedPdf
                                   :disable_internal_links,
                                   :disable_external_links,
                                   :print_media_type,
+                                  :enable_local_file_access,
                                   :disable_smart_shrinking,
                                   :use_xserver,
                                   :no_background,

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -316,6 +316,7 @@ class WickedPdf
                                   :disable_internal_links,
                                   :disable_external_links,
                                   :print_media_type,
+                                  :disable_local_file_access,
                                   :enable_local_file_access,
                                   :disable_smart_shrinking,
                                   :use_xserver,

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -175,7 +175,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     [
       :book, :default_header, :disable_javascript, :grayscale, :lowquality,
       :enable_plugins, :disable_internal_links, :disable_external_links,
-      :print_media_type, :disable_smart_shrinking, :use_xserver, :no_background
+      :print_media_type, :enable_local_file_access, :disable_smart_shrinking, :use_xserver, :no_background
     ].each do |o|
       assert_equal "--#{o.to_s.tr('_', '-')}", @wp.get_parsed_options(o => true).strip
     end

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -175,7 +175,7 @@ class WickedPdfTest < ActiveSupport::TestCase
     [
       :book, :default_header, :disable_javascript, :grayscale, :lowquality,
       :enable_plugins, :disable_internal_links, :disable_external_links,
-      :print_media_type, :enable_local_file_access, :disable_smart_shrinking, :use_xserver, :no_background
+      :print_media_type, :disable_smart_shrinking, :use_xserver, :no_background
     ].each do |o|
       assert_equal "--#{o.to_s.tr('_', '-')}", @wp.get_parsed_options(o => true).strip
     end


### PR DESCRIPTION
@unixmonkey  @mileszs  👍 

The 0.12.6 version of wkhtmltopdf  has a breaking change option, that is true by default, related to local file access. 

Link for breaking change in WkHtmlToPDF 0.12.6:
https://github.com/wkhtmltopdf/wkhtmltopdf/releases/tag/0.12.6
https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4536
https://github.com/wkhtmltopdf/wkhtmltopdf/blob/0.12.6/src/shared/commonarguments.cc#L227-L228

The local file access, that was enabled by default in <= 0.12.5, now is false by default in 0.12.6+