### PR TITLE
Remove code for unsupported rails and ruby versions

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -8,11 +8,7 @@ class WickedPdf
       base.class_eval do
         alias_method_chain :render, :wicked_pdf
         alias_method_chain :render_to_string, :wicked_pdf
-        if respond_to?(:after_action)
-          after_action :clean_temp_files
-        else
-          after_filter :clean_temp_files
-        end
+        after_action :clean_temp_files
       end
     end
 

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -1,17 +1,5 @@
 class WickedPdf
   module PdfHelper
-    def self.included(base)
-      # Protect from trying to augment modules that appear
-      # as the result of adding other gems.
-      return if base != ActionController::Base
-
-      base.class_eval do
-        alias_method_chain :render, :wicked_pdf
-        alias_method_chain :render_to_string, :wicked_pdf
-        after_action :clean_temp_files
-      end
-    end
-
     def self.prepended(base)
       # Protect from trying to augment modules that appear
       # as the result of adding other gems.
@@ -22,39 +10,37 @@ class WickedPdf
       end
     end
 
-    def render(options = nil, *args, &block)
-      render_with_wicked_pdf(options, *args, &block)
-    end
-
-    def render_to_string(options = nil, *args, &block)
-      render_to_string_with_wicked_pdf(options, *args, &block)
-    end
-
-    def render_with_wicked_pdf(options = nil, *args, &block)
+    def render(*args)
+      options = args.first
       if options.is_a?(Hash) && options.key?(:pdf)
-        options[:basic_auth] = set_basic_auth(options)
-        make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
-      elsif respond_to?(:render_without_wicked_pdf)
-        # support alias_method_chain (module included)
-        render_without_wicked_pdf(options, *args, &block)
+        render_with_wicked_pdf(options)
       else
-        # support inheritance (module prepended)
-        method(:render).super_method.call(options, *args, &block)
+        super
       end
     end
 
-    def render_to_string_with_wicked_pdf(options = nil, *args, &block)
+    def render_to_string(*args)
+      options = args.first
       if options.is_a?(Hash) && options.key?(:pdf)
-        options[:basic_auth] = set_basic_auth(options)
-        options.delete :pdf
-        make_pdf((WickedPdf.config || {}).merge(options))
-      elsif respond_to?(:render_to_string_without_wicked_pdf)
-        # support alias_method_chain (module included)
-        render_to_string_without_wicked_pdf(options, *args, &block)
+        render_to_string_with_wicked_pdf(options, *args, &block)
       else
-        # support inheritance (module prepended)
-        method(:render_to_string).super_method.call(options, *args, &block)
+        super
       end
+    end
+
+    def render_with_wicked_pdf(options)
+      raise ArgumentError, 'missing keyword: pdf' unless options.is_a?(Hash) && options.key?(:pdf)
+
+      options[:basic_auth] = set_basic_auth(options)
+      make_and_send_pdf(options.delete(:pdf), (WickedPdf.config || {}).merge(options))
+    end
+
+    def render_to_string_with_wicked_pdf(options)
+      raise ArgumentError, 'missing keyword: pdf' unless options.is_a?(Hash) && options.key?(:pdf)
+
+      options[:basic_auth] = set_basic_auth(options)
+      options.delete :pdf
+      make_pdf((WickedPdf.config || {}).merge(options))
     end
 
     private

--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -7,12 +7,7 @@ class WickedPdf
     class WickedRailtie < Rails::Railtie
       initializer 'wicked_pdf.register', :after => 'remotipart.controller_helper' do |_app|
         ActiveSupport.on_load(:action_controller) do
-          if ActionController::Base.respond_to?(:prepend) &&
-             Object.method(:new).respond_to?(:super_method)
-            ActionController::Base.send :prepend, PdfHelper
-          else
-            ActionController::Base.send :include, PdfHelper
-          end
+          ActionController::Base.send :prepend, PdfHelper
           ActionView::Base.send :include, WickedPdfHelper::Assets
         end
       end


### PR DESCRIPTION
Since rails < 4 and ruby < 2.2 are unsupported, we can assume that `ActionController::Base.after_action` and `Module.prepend` exist.

This fixes https://github.com/github/view_component/issues/288 , and should fix #111 (but didn't test)