### PR TITLE
Include WickedPdfHelper::Assets in the right instance of ActionView::Base

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -13,7 +13,9 @@ class WickedPdf
           else
             ActionController::Base.send :include, PdfHelper
           end
-          ActionView::Base.send :include, WickedPdfHelper::Assets
+        end
+        ActiveSupport.on_load(:action_view) do
+          include WickedPdfHelper::Assets
         end
       end
     end


### PR DESCRIPTION
**Context:**

A Rails application with `config.action_controller.asset_host` defined (CDN such as cloudfront)

**Problem:**

In a view rendered by a controller, `asset_path` returns a full url but through wicked_pdf, `asset_path` returns only a path (without the host), thus breaking assets provided through a CDN.

We can work around this issue by giving an absolute url to `wicked_pdf_image_tag` but it's not ideal.

```ruby
# This won't work with a CDN
wicked_pdf_image_tag 'file.png'

# This works with a CDN
wicked_pdf_image_tag ActionController::Base.helpers.asset_path('file.png')
```

**Solution:**

I suggest to fix `lib/wicked_pdf/railtie.rb` to make `asset_path` (which is used in `lib/wicked_pdf/wicked_pdf_helper/assets.rb`) aware of `config.action_controller.asset_host` for it to work as expected.

The fix consist of including `WickedPdfHelper::Assets` in the right instance of `ActionView::Base` once it's loaded.