### PR TITLE
Add `wicked_pdf_url_base64`.

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -15,6 +15,20 @@ class WickedPdf
         "data:#{asset.content_type};base64,#{Rack::Utils.escape(base64)}"
       end
 
+      # Using `image_tag` with URLs when generating PDFs (specifically large PDFs with lots of pages) can cause buffer/stack overflows.
+      #
+      def wicked_pdf_url_base64(url)
+        response = Net::HTTP.get_response(URI(url))
+
+        if response.is_a?(Net::HTTPSuccess)
+          base64 = Base64.encode64(response.body).gsub(/\s+/, '')
+          "data:#{response.content_type};base64,#{Rack::Utils.escape(base64)}"
+        else
+          Rails.logger.warn("[wicked_pdf] #{response.code} #{response.message}: #{url}")
+          nil
+        end
+      end
+
       def wicked_pdf_stylesheet_link_tag(*sources)
         stylesheet_contents = sources.collect do |source|
           source = WickedPdfHelper.add_extension(source, 'css')


### PR DESCRIPTION
_We're using this in production to solve our problem. Looking to get some feedback from @mileszs before finalizing this properly and, hopefully, getting it merged to help others in similar situations._

Using URLs to reference images can cause a lot of problems with wkhtmltopdf, particularly when used in the header and footer. It produces errors such as "Too many open files" as well as buffer/stack overflows. These issues can be seen here, among other places: 

- https://github.com/mileszs/wicked_pdf/issues/288
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1819
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3019
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2093
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4762
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3081
- https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4296

As described [here](https://github.com/mileszs/wicked_pdf/issues/288#issuecomment-130106916), one of the key solutions to avoiding this issue is providing the image encoded as base64. This helper method takes a URL of an image, opens the URL, reads the image data and encodes it to base64.

If the URL cannot be open (`OpenURI::HTTPError` is raised), it will log a warning and return `nil`.

### TODOs:

- [ ] Better placement (since this is not technically part of the asset pipeline)?
- [ ] Better naming?
- [ ] Tests.