### PR TITLE
Do not unlink HTML temp files immediately.

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -47,7 +47,7 @@ class WickedPdf
     pdf = pdf_from_html_file(string_file.path, options)
     pdf
   ensure
-    string_file.close! if string_file
+    string_file.close if string_file
   end
 
   def pdf_from_url(url, options = {})

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -73,7 +73,7 @@ class WickedPdf
     def clean_temp_files
       return unless defined?(@hf_tempfiles)
 
-      @hf_tempfiles.each(&:close!)
+      @hf_tempfiles.each(&:close)
     end
 
     def make_pdf(options = {})


### PR DESCRIPTION
The reason for not wanting to unlink them is primariily for debugging. If an error occurs, the `wkhtmltopdf` command that had problems is shown as part of the error message. Something like this: 

```
Failed to execute:
["/Users/me/.rbenv/versions/2.6.5/bin/wkhtmltopdf", "--enable-local-file-access", "--disable-smart-shrinking", "--orientation", "Portrait", "--page-size", "Letter", "--margin-top", "27", "--margin-bottom", "19", "--header-html", "file:////var/folders/9n/vjrv4bzs7fxf6crkdc84tf740000gn/T/wicked_header_pdf20201023-55115-le3quo.html", "--footer-html", "file:////var/folders/9n/vjrv4bzs7fxf6crkdc84tf740000gn/T/wicked_footer_pdf20201023-55115-1o98lhe.html", "file:////var/folders/9n/vjrv4bzs7fxf6crkdc84tf740000gn/T/wicked_pdf20201023-55115-1am8ara.html", "/var/folders/9n/vjrv4bzs7fxf6crkdc84tf740000gn/T/wicked_pdf_generated_file20201023-55115-qwkucc.pdf"]
Error: Invalid argument @ io_fread - ### /var/folders/9n/vjrv4bzs7fxf6crkdc84tf740000gn/T/wicked_pdf_generated_file20201023-55115-qwkucc.pdf
```

However, the references to the HTML temp files used in that command are no longer there so it's very difficult to reproduce or investigate further.

We want to keep these files around so that you can essentially run the nearly identical `wkhtmltopdf` command when there was an error and dig deeper into it.

Keeping these files does not keep them forever. They are, afterall, temp files and will be cleaned up automatically by the system.

To accomplish this, we use `.close` instead of `.close!`, which does not unlink the file immediately after closing it.

NOTE: We still want to use `.close!` on the generated PDF files for two reasons:

1. This generated PDF file is not important when an error has occurred and you are re-running the `wkhtmltopdf` command.

2. The generated PDF file is the largest of the files. Typically, the HTML files for header, footer and body are relatively small compared to the generated PDF file.

Fixes #948.