### PR TITLE
Extract reading and writing files in chunks

### DIFF
--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -61,7 +61,7 @@ class WickedPdf
           r += make_options(opt_hf, [:line], hf.to_s, :boolean)
           if options[hf] && options[hf][:content]
             @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-            @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+            @hf_tempfiles.push(tf = WickedPdf::Tempfile.new("wicked_#{hf}_pdf.html"))
             tf.write options[hf][:content]
             tf.flush
             options[hf][:html] = {}
@@ -84,7 +84,7 @@ class WickedPdf
         [valid_option('cover'), arg]
       else # HTML content
         @hf_tempfiles ||= []
-        @hf_tempfiles << tf = WickedPdfTempfile.new('wicked_cover_pdf.html')
+        @hf_tempfiles << tf = WickedPdf::Tempfile.new('wicked_cover_pdf.html')
         tf.write arg
         tf.flush
         [valid_option('cover'), tf.path]

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -125,7 +125,7 @@ class WickedPdf
         next unless options[hf] && options[hf][:html] && options[hf][:html][:template]
 
         @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-        @hf_tempfiles.push(tf = WickedPdfTempfile.new("wicked_#{hf}_pdf.html"))
+        @hf_tempfiles.push(tf = WickedPdf::Tempfile.new("wicked_#{hf}_pdf.html"))
         options[hf][:html][:layout] ||= options[:layout]
         render_opts = {
           :template => options[hf][:html][:template],

--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -1,13 +1,42 @@
 require 'tempfile'
 
 class WickedPdf
-  class WickedPdfTempfile < Tempfile
-    # ensures the Tempfile's filename always keeps its extension
+  class Tempfile < ::Tempfile
     def initialize(filename, temp_dir = nil)
       temp_dir ||= Dir.tmpdir
       extension = File.extname(filename)
-      basename  = File.basename(filename, extension)
+      basename = File.basename(filename, extension)
       super([basename, extension], temp_dir)
+    end
+
+    def write_in_chunks(input_string)
+      binmode
+      string_io = StringIO.new(input_string)
+      write(string_io.read(chunk_size)) until string_io.eof?
+      close
+      self
+    rescue Errno::EINVAL => e
+      raise e, file_too_large_message
+    end
+
+    def read_in_chunks
+      rewind
+      binmode
+      output_string = ''
+      output_string << read(chunk_size) until eof?
+      output_string
+    rescue Errno::EINVAL => e
+      raise e, file_too_large_message
+    end
+
+    private
+
+    def chunk_size
+      1024 * 1024
+    end
+
+    def file_too_large_message
+      'The HTML file is too large! Try reducing the size or using the return_file option instead.'
     end
   end
 end


### PR DESCRIPTION
In https://github.com/mileszs/wicked_pdf/pull/949 we made it so that files are written to and read from in chunks, which improves outcomes when creating large PDFs on memory-constrained system. This PR extracts this work into the `WickedPdf::Tempfile` class to clean up the main `pdf_from_string` and `pdf_from_url` methods.