### PR TITLE
Use Open3.capture3 to avoid deadlock between stdout/stderr in subprocess

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -58,11 +58,13 @@ class WickedPdf
 
     print_command(command.inspect) if in_development_mode?
 
+    err = ''
     if track_progress?(options)
       invoke_with_progress(command, options)
     else
-      err = Open3.popen3(*command) do |_stdin, _stdout, stderr|
-        stderr.read
+      _out, err, status = Open3.capture3(*command)
+      if !err.empty? || !status.success?
+        err = status.to_s + "\n" + err
       end
     end
     if options[:return_file]

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -63,9 +63,7 @@ class WickedPdf
       invoke_with_progress(command, options)
     else
       _out, err, status = Open3.capture3(*command)
-      if !err.empty? || !status.success?
-        err = status.to_s + "\n" + err
-      end
+      err = [status.to_s, err].join("\n") if !err.empty? || !status.success?
     end
     if options[:return_file]
       return_file = options.delete(:return_file)


### PR DESCRIPTION
While investigating a possible issue with our internal use of wicked_pdf / wkhtmltopdf, I found this issue in the source.

After opening the wkhtmltopdf subprocess we attempt to read stderr, and we later use that data to determine whether the process failed or not. But because stdout is open and we ignore it, there is a possibility that the process may deadlock. This can happen if wkhtmltopdf fills its stdout buffer before writing to stderr, in which case the kernel will pause the wkhtmltopdf process until someone reads the buffered stdout data. Because it is paused, there can be no new data written to stderr, which blocks ruby and would cause deadlock.

See discussion here re: Open3.popen3 https://docs.ruby-lang.org/en/2.0.0/Open3.html#method-i-popen3

This patch replaces popen3 with capture3, which allows Open3 to manage the process pipes and simply returns the full stdout, stderr, and process exit status after the subprocess completes. I've also added the process status to the error message and added a case to cover the possibility that the process exits with an error code but does not print anything to stderr.

I haven't added any test cases, but I believe that existing test coverage should guarantee that the subprocess call still works as expected.