### PR TITLE
render_to_string fix

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -22,7 +22,7 @@ class WickedPdf
     def render_to_string(*args)
       options = args.first
       if options.is_a?(Hash) && options.key?(:pdf)
-        render_to_string_with_wicked_pdf(options, *args, &block)
+        render_to_string_with_wicked_pdf(options)
       else
         super
       end


### PR DESCRIPTION
pass options only to the render_to_string_with_wicked_pdf