### PR TITLE
Fix check webpacker version

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -1,6 +1,4 @@
 require 'net/http'
-# If webpacker is used, need to check for version
-require 'webpacker/version' if defined?(Webpacker)
 
 class WickedPdf
   module WickedPdfHelper
@@ -187,10 +185,10 @@ class WickedPdf
       end
 
       def webpacker_source_url(source)
-        return unless defined?(Webpacker) && defined?(Webpacker::VERSION)
+        return unless Assets.webpacker_version
 
         # In Webpacker 3.2.0 asset_pack_url is introduced
-        if Webpacker::VERSION >= '3.2.0'
+        if Assets.webpacker_version >= '3.2.0'
           asset_pack_url(source)
         else
           source_path = asset_pack_path(source)
@@ -200,7 +198,7 @@ class WickedPdf
       end
 
       def running_in_development?
-        return unless defined?(Webpacker)
+        return unless Assets.webpacker_version
 
         # :dev_server method was added in webpacker 3.0.0
         if Webpacker.respond_to?(:dev_server)
@@ -208,6 +206,15 @@ class WickedPdf
         else
           Rails.env.development? || Rails.env.test?
         end
+      end
+
+      def self.webpacker_version
+        return unless defined?(Webpacker)
+        
+        # If webpacker is used, need to check for version
+        require 'webpacker/version' 
+
+        Webpacker::VERSION
       end
     end
   end


### PR DESCRIPTION
Webpacker's version check is failed if webpacker follows for wicked_pdf in Gemfile. 

Webpacker is not defined at the gem initialization in the case. 
```ruby
require 'net/http'
# If webpacker is used, need to check for version
require 'webpacker/version' if defined?(Webpacker)
```

`Webpacker::VERSION` constant not defined unless 'webpacker/version' required. And `webpacker_source_url(source)` returns `nil`
```ruby
def webpacker_source_url(source)
  return unless defined?(Webpacker) && defined?(Webpacker::VERSION)
  ...
end
```