### PR TITLE
fix url generating in webpacker helper

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -191,7 +191,7 @@ class WickedPdf
 
         # In Webpacker 3.2.0 asset_pack_url is introduced
         if Webpacker::VERSION >= '3.2.0'
-          asset_pack_url(source)
+          asset_pack_path(source, host: Rails.application.config.asset_host || root_url)
         else
           source_path = asset_pack_path(source)
           # Remove last slash from root path


### PR DESCRIPTION
There are a lot of issues that are connected with this fix.
Some of them: https://github.com/mileszs/wicked_pdf/issues/961, https://github.com/mileszs/wicked_pdf/issues/923, https://github.com/mileszs/wicked_pdf/issues/860

Most of the projects don't use the `asset_host` config. I think it can help many people to avoid monkey patching and so on.