### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        gemfile: []
-        ruby-version: []
+        gemfile: [""]
+        ruby-version: [""]
         include:
           - gemfile: 4.0
             ruby-version: 2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get install -y wkhtmltopdf
 
+      - name: Update rubygems and bundler
+        run: |
+          gem update --system
+          gem install bundler
+
       - name: Install gem dependencies
         run: bundle install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  ci:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ruby-version: 3.0
 
     env:
-      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_GEMFILE: /home/runner/work/wicked_pdf/wicked_pdf/gemfiles/${{ matrix.gemfile }}.gemfile
       WKHTMLTOPDF_BIN: /usr/bin/wkhtmltopdf
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,9 @@ jobs:
 
     strategy:
       matrix:
-        gemfile: [""]
-        ruby-version: [""]
+        gemfile: ["4.0"]
+        ruby-version: [2.2]
         include:
-          - gemfile: "4.0"
-            ruby-version: 2.2
           - gemfile: "4.1"
             ruby-version: 2.2
           - gemfile: "4.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           sudo apt-get install -y wkhtmltopdf
 
       - name: Update rubygems and bundler
+        if: ${{ matrix.ruby-version != '2.2' && matrix.ruby-version != '2.3' }}
         run: |
           gem update --system
           gem install bundler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        gemfile: []
+        ruby-version: []
+        include:
+          - gemfile: 4.0
+            ruby-version: 2.2
+          - gemfile: 4.1
+            ruby-version: 2.2
+          - gemfile: 4.2
+            ruby-version: 2.2
+          - gemfile: 5.0
+            ruby-version: 2.3
+          - gemfile: 5.1
+            ruby-version: 2.4
+          - gemfile: 5.2
+            ruby-version: 2.5
+          - gemfile: 5.2
+            ruby-version: 2.6
+          - gemfile: 6.0
+            ruby-version: 2.6
+          - gemfile: 6.0
+            ruby-version: 2.7
+          - gemfile: 6.0
+            ruby-version: 3.0
+          - gemfile: rails_edge
+            ruby-version: 2.7
+          - gemfile: rails_edge
+            ruby-version: 3.0
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      WKHTMLTOPDF_BIN: /usr/bin/wkhtmltopdf
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y wkhtmltopdf
+
+      - name: Install gem dependencies
+        run: bundle install
+
+      - name: Run tests with Ruby ${{ matrix.ruby-version }} and Gemfile ${{ matrix.gemfile }}
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
             ruby-version: 2.6
           - gemfile: "6.0"
             ruby-version: 2.7
-          - gemfile: "rails_edge"
-            ruby-version: 2.7
 
     env:
       BUNDLE_GEMFILE: /home/runner/work/wicked_pdf/wicked_pdf/gemfiles/${{ matrix.gemfile }}.gemfile
@@ -39,11 +37,6 @@ jobs:
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install -y wkhtmltopdf
-
-      - name: Update rubygems and bundler
-        run: |
-          gem update --system
-          gem install bundler
 
       - name: Install gem dependencies
         run: bundle install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   ci:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         gemfile: ["4.0"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
             ruby-version: 2.6
           - gemfile: "6.0"
             ruby-version: 2.7
-          - gemfile: "6.1"
-            ruby-version: 3.0
           - gemfile: "rails_edge"
             ruby-version: 2.7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: ["4.0"]
-        ruby-version: [2.2]
+        gemfile: ["rails_edge"]
+        ruby-version: [3.0]
         include:
-          - gemfile: "4.1"
-            ruby-version: 2.2
-          - gemfile: "4.2"
-            ruby-version: 2.2
           - gemfile: "5.0"
             ruby-version: 2.3
           - gemfile: "5.1"
@@ -30,8 +26,6 @@ jobs:
             ruby-version: 3.0
           - gemfile: "rails_edge"
             ruby-version: 2.7
-          - gemfile: "rails_edge"
-            ruby-version: 3.0
 
     env:
       BUNDLE_GEMFILE: /home/runner/work/wicked_pdf/wicked_pdf/gemfiles/${{ matrix.gemfile }}.gemfile
@@ -51,7 +45,6 @@ jobs:
           sudo apt-get install -y wkhtmltopdf
 
       - name: Update rubygems and bundler
-        if: ${{ matrix.ruby-version != '2.2' && matrix.ruby-version != '2.3' }}
         run: |
           gem update --system
           gem install bundler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             ruby-version: 2.6
           - gemfile: "6.0"
             ruby-version: 2.7
-          - gemfile: "6.0"
+          - gemfile: "6.1"
             ruby-version: 3.0
           - gemfile: "rails_edge"
             ruby-version: 2.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,29 +11,29 @@ jobs:
         gemfile: [""]
         ruby-version: [""]
         include:
-          - gemfile: 4.0
+          - gemfile: "4.0"
             ruby-version: 2.2
-          - gemfile: 4.1
+          - gemfile: "4.1"
             ruby-version: 2.2
-          - gemfile: 4.2
+          - gemfile: "4.2"
             ruby-version: 2.2
-          - gemfile: 5.0
+          - gemfile: "5.0"
             ruby-version: 2.3
-          - gemfile: 5.1
+          - gemfile: "5.1"
             ruby-version: 2.4
-          - gemfile: 5.2
+          - gemfile: "5.2"
             ruby-version: 2.5
-          - gemfile: 5.2
+          - gemfile: "5.2"
             ruby-version: 2.6
-          - gemfile: 6.0
+          - gemfile: "6.0"
             ruby-version: 2.6
-          - gemfile: 6.0
+          - gemfile: "6.0"
             ruby-version: 2.7
-          - gemfile: 6.0
+          - gemfile: "6.0"
             ruby-version: 3.0
-          - gemfile: rails_edge
+          - gemfile: "rails_edge"
             ruby-version: 2.7
-          - gemfile: rails_edge
+          - gemfile: "rails_edge"
             ruby-version: 3.0
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gemfile: ["rails_edge"]
-        ruby-version: [3.0]
+        gemfile: ["5.0"]
+        ruby-version: [2.3]
         include:
-          - gemfile: "5.0"
-            ruby-version: 2.3
           - gemfile: "5.1"
             ruby-version: 2.4
           - gemfile: "5.2"


### PR DESCRIPTION
Hi, @unixmonkey ! 👋 

I noticed that CI is red/failing for latest commits in repo. I thought that can be a good idea to switch to Github Actions CI, in order to make it green again and also not depends on Travis CI (that changed policies/usage limits recently).

For a while, I've added to CI only stable rails versions, and versions that are maintained at this moment.

Let me know what do you think about 🤝 🍻  Your eyes/review on it will be awesome 🕺 

Thanks a lot!