### PR TITLE
Include view helper on view load.

### DIFF
--- a/lib/wicked_pdf/railtie.rb
+++ b/lib/wicked_pdf/railtie.rb
@@ -6,10 +6,8 @@ class WickedPdf
   if defined?(Rails.env)
     class WickedRailtie < Rails::Railtie
       initializer 'wicked_pdf.register', :after => 'remotipart.controller_helper' do |_app|
-        ActiveSupport.on_load(:action_controller) do
-          ActionController::Base.send :prepend, PdfHelper
-          ActionView::Base.send :include, WickedPdfHelper::Assets
-        end
+        ActiveSupport.on_load(:action_controller) { ActionController::Base.send :prepend, PdfHelper }
+        ActiveSupport.on_load(:action_view) { include WickedPdfHelper::Assets }
       end
     end
 


### PR DESCRIPTION
We ran into some problems using this gem with our Rails 6 app that adds a lot of custom paths to Zeitwerk's autoloaders. Narrowed it down to the view helper being included in `ActionView::Base` during the action_controller load hook rather than in the action_view load hook.

This change fixed the issue for us, and it feels better than accessing a private method.