### PR TITLE
fix: `webpacker_source_url`

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -191,7 +191,11 @@ class WickedPdf
 
         # In Webpacker 3.2.0 asset_pack_url is introduced
         if Webpacker::VERSION >= '3.2.0'
-          asset_pack_path(source, :host => Rails.application.config.asset_host || root_url)
+          if (host = Rails.application.config.asset_host)
+            asset_pack_path(source, :host => host)
+          else
+            asset_pack_url(source)
+          end
         else
           source_path = asset_pack_path(source)
           # Remove last slash from root path


### PR DESCRIPTION
Since the change in #973, I've experienced an issue where images are not
being embedding in the pdf generated (in non development environments)
when using the following:

```
image_tag wicked_pdf_asset_pack_path("static/example.png")
```

For context: The pdfs are being generated via a background job on a
separate sever to the webapp, so using the `asset_host` option is not
ideal, as the pdf would then need to fetch the assets from another server
when they're already available locally. Although not ideal, I have tried setting
`Rails.application.config.asset_host` via `production.rb` to no avail.

This commit reinstates the original functionality prior to #973, whist
still retaining the new functionality add via #973.