### PR TITLE
Flush Tempfile when writing in chunks

### DIFF
--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -13,6 +13,7 @@ class WickedPdf
       binmode
       string_io = StringIO.new(input_string)
       write(string_io.read(chunk_size)) until string_io.eof?
+      flush
       close
       self
     rescue Errno::EINVAL => e


### PR DESCRIPTION
## Why is this PR needed?

When using `wicked_pdf` we ran into multiple random errors with no error reason like this:

```
Failed to execute: ["/usr/local/bundle/bin/wkhtmltopdf", "--viewport-size", "1280x1024", "--zoom", "1.2", "file:////app/tmp/wicked_pdf20211115-11790-d86958.html", "/app/tmp/wicked_pdf_generated_file20211115-11790-bfoat9.pdf"] Error: PDF could not be generated! Command Error:
```

It appears that `wkhtmltopdf` binary produces empty PDF file, and this raises the blank 'Command Error'

## Solution

Do `.flush` the temp input file to ensure it has data available for `wkhtmltopdf ` process