### PR TITLE
"require 'delegate'" for compatibility with ruby 2.7

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'delegate'
 
 class WickedPdf
   module WickedPdfHelper


### PR DESCRIPTION
When running wicked_pdf with ruby 2.7 in a non-rails environment the following error is encountered:
`uninitialized constant WickedPdf::WickedPdfHelper::Assets::SimpleDelegator`

The delegate library was loaded by default in older versions of ruby, but in 2.7 this is not the case. Explicitly requiring delegate in assets.rb resolves the issue.