### PR TITLE
Add support for truffleruby (22.1.0) on Linux

### DIFF
--- a/lib/wicked_pdf/progress.rb
+++ b/lib/wicked_pdf/progress.rb
@@ -1,10 +1,10 @@
 class WickedPdf
   module Progress
-    require 'pty' if RbConfig::CONFIG['target_os'] !~ /mswin|mingw/ # no support for windows
+    require 'pty' if RbConfig::CONFIG['target_os'] !~ /mswin|mingw/ && RUBY_ENGINE != 'truffleruby' # no support for windows and truffleruby
     require 'English'
 
     def track_progress?(options)
-      options[:progress] && !on_windows?
+      options[:progress] && !(on_windows? || RUBY_ENGINE == 'truffleruby')
     end
 
     def invoke_with_progress(command, options)


### PR DESCRIPTION
Add support for truffleruby (22.1.0). 

Cause this feature is not supported by truffleruby (22.1.0) yet: https://github.com/oracle/truffleruby/blob/master/doc/user/compatibility.md#standard-libraries

Without commit PR got error:

```
<internal:core> core/kernel.rb:236:in `gem_original_require': cannot load such file -- pty (LoadError)
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/wicked_pdf-2.6.3/lib/wicked_pdf/progress.rb:3:in `<module:Progress>'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/wicked_pdf-2.6.3/lib/wicked_pdf/progress.rb:2:in `<class:WickedPdf>'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/wicked_pdf-2.6.3/lib/wicked_pdf/progress.rb:1:in `<top (required)>'
        from <internal:core> core/kernel.rb:234:in `gem_original_require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/wicked_pdf-2.6.3/lib/wicked_pdf.rb:18:in `<top (required)>'
        from <internal:core> core/kernel.rb:234:in `gem_original_require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler/runtime.rb:55:in `each'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler/runtime.rb:55:in `block in require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler/runtime.rb:44:in `each'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler/runtime.rb:44:in `require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/bundler-2.3.15/lib/bundler.rb:187:in `require'
        from /etc/base_ruby_on_rails_trade/trade/config/application.rb:20:in `<top (required)>'
        from <internal:core> core/kernel.rb:234:in `gem_original_require'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/railties-7.0.3/lib/rails/commands/server/server_command.rb:137:in `block in perform'
        from <internal:core> core/kernel.rb:510:in `tap'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/railties-7.0.3/lib/rails/commands/server/server_command.rb:134:in `perform'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/railties-7.0.3/lib/rails/command/base.rb:87:in `perform'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/railties-7.0.3/lib/rails/command.rb:48:in `invoke'
        from /root/.rbenv/versions/truffleruby+graalvm-22.1.0/graalvm/languages/ruby/lib/gems/gems/railties-7.0.3/lib/rails/commands.rb:18:in `<top (required)>'

        from <internal:core> core/kernel.rb:234:in `gem_original_require'
        from bin/rails:4:in `<main>'
```