### PR TITLE
Bump rubocop to 1.46

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -34,7 +34,7 @@ DESC
   spec.add_development_dependency 'mocha', '= 1.3'
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop', '~> 1.24'
+  spec.add_development_dependency 'rubocop', '~> 1.46'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Hi!

Bumping rubocop to the most recent version as we are using wicked_pdf in production but it's preventing us from running a more recent version of rubocop that supports Ruby 3.2