### PR TITLE
Ensure header/footer temp files are closed before wkhtmltopdf uses them

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -79,7 +79,7 @@ class WickedPdf
   rescue StandardError => e
     raise "Failed to execute:\n#{command}\nError: #{e}"
   ensure
-    clean_temp_files
+    option_parser.clean_temp_files
     generated_pdf_file.close! if generated_pdf_file && !return_file
   end
 
@@ -101,11 +101,5 @@ class WickedPdf
 
   def option_parser
     @option_parser ||= OptionParser.new(binary_version)
-  end
-
-  def clean_temp_files
-    return unless option_parser.hf_tempfiles.present?
-
-    option_parser.hf_tempfiles.each { |file| File.delete(file) }
   end
 end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -5,6 +5,7 @@ require 'logger'
 require 'digest/md5'
 require 'rbconfig'
 require 'open3'
+require 'uri'
 
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/object/blank'
@@ -33,7 +34,7 @@ class WickedPdf
   end
 
   def pdf_from_html_file(filepath, options = {})
-    pdf_from_url("file:///#{filepath}", options)
+    pdf_from_url(URI.join('file:', '', filepath).to_s, options)
   end
 
   def pdf_from_string(string, options = {})

--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -64,6 +64,7 @@ class WickedPdf
             @hf_tempfiles.push(tf = File.new(Dir::Tmpname.create(["wicked_#{hf}_pdf", '.html']) {}, 'w'))
             tf.write options[hf][:content]
             tf.flush
+            tf.close
             options[hf][:html] = {}
             options[hf][:html][:url] = "file:///#{tf.path}"
           end
@@ -87,6 +88,7 @@ class WickedPdf
         @hf_tempfiles << tf = WickedPdf::Tempfile.new('wicked_cover_pdf.html')
         tf.write arg
         tf.flush
+        tf.close
         [valid_option('cover'), tf.path]
       end
     end

--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -120,7 +120,7 @@ class WickedPdf
         render_opts[:file] = options[hf][:html][:file] if options[:file]
         tf.write render_to_string(render_opts)
         tf.flush
-        options[hf][:html][:url] = "file:///#{tf.path}"
+        options[hf][:html][:url] = URI.join('file:', '', tf.path).to_s
       end
       options
     end

--- a/lib/wicked_pdf/wicked_pdf_helper.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper.rb
@@ -18,13 +18,15 @@ class WickedPdf
     end
 
     def wicked_pdf_image_tag(img, options = {})
-      image_tag "file:///#{WickedPdfHelper.root_path.join('public', 'images', img)}", options
+      path = WickedPdfHelper.root_path.join('public', 'images', img)
+      image_tag URI.join('file:', '', path).to_s, options
     end
 
     def wicked_pdf_javascript_src_tag(jsfile, options = {})
       jsfile = WickedPdfHelper.add_extension(jsfile, 'js')
       type = ::Mime.respond_to?(:[]) ? ::Mime[:js] : ::Mime::JS # ::Mime[:js] cannot be used in Rails 2.3.
-      src = "file:///#{WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)}"
+      path = WickedPdfHelper.root_path.join('public', 'javascripts', jsfile)
+      src = URI.join('file:', '', path).to_s
       content_tag('script', '', { 'type' => type, 'src' => path_to_javascript(src) }.merge(options))
     end
 

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -104,7 +104,7 @@ class WickedPdf
         if (pathname = asset_pathname(asset).to_s) =~ URI_REGEXP
           pathname
         else
-          "file:///#{pathname}"
+          URI.join('file:', '', pathname).to_s
         end
       end
 


### PR DESCRIPTION
Recently was applied the PR #1039 but it was failing on windows environment causing `permission denied` error on created headers and footers temp files. This was caused in my case because the new way to handle temp files does not `.close` the files, causing an access error on windows env when `wkhtmltopdf` attempts to use them later. This PR fix the problem closing the files after creation and let them free to be used by another process on windows (and also linux).

On the other hand, the new variable used to hold the temp files objects prevents that files were destroyed by garbage collector (the original issue), but when one reuse the same `WickedPdf` instance, the variable `hf_tempfiles` on `OptionParser` class is not cleared resulting on failiures when it tries to delete files that dont exists anymore (because there was information created on a previous use of the `WickedPdf` class). This fix that situation moving the logic of cleaning tempfiles at `OptionParser` class, and clearing the `hf_tempfiles` after remove the files, letting it clean for a new call of its methods.

And the last change that I made is using `URI` to create local files `url` (File:///) to follow the convention of `ruby` and make it more secure and standarized.