### PR TITLE
require stringio

### DIFF
--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'stringio'
 
 class WickedPdf
   class Tempfile < ::Tempfile

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'delegate'
+require 'stringio'
 
 class WickedPdf
   module WickedPdfHelper


### PR DESCRIPTION
When running WickedPDF via the ruby command using ruby 3.1, I received 

```
/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/delegate.rb:61:in `const_get': uninitialized constant StringIO (NameError)
```

when running the following command

```
"bundle exec ruby -e 'require \"wicked_pdf\"; WickedPdf.new.pdf_from_string(\"<p>Ya did it</p>\"); puts \"todo es bueno\"'"

In all examples I've seen this used, we should first require this. 