### PR TITLE
require stringio before use

### DIFF
--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'stringio'
 
 class WickedPdf
   class Tempfile < ::Tempfile

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'delegate'
+require 'stringio'
 
 class WickedPdf
   module WickedPdfHelper


### PR DESCRIPTION
Hello! 

I upgraded to Ruby 3.1, and when I did i started receiving errors that uninitialized constant StringIO (NameError).  I feel this is similar to the PR for require delegate that had been addressed earlier.  

https://github.com/mileszs/wicked_pdf/pull/1019/files

When running WickedPDF via the ruby command using ruby 3.1, I received

```
/usr/local/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/delegate.rb:61:in `const_get': uninitialized constant StringIO (NameError)
```

when running the following command

```
"bundle exec ruby -e 'require \"wicked_pdf\"; WickedPdf.new.pdf_from_string(\"<p>Ya did it</p>\"); puts \"great!"'"
```

In all examples I've seen this used, we should first require this. 

https://ruby-doc.org/stdlib-2.5.1/libdoc/stringio/rdoc/StringIO.html

Thank you 