### PR TITLE
Shakapacker 7 compatibility (#1066)

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -231,12 +231,11 @@ class WickedPdf
       end
 
       def webpacker_version
-        return unless defined?(Webpacker)
-
-        # If webpacker is used, need to check for version
-        require 'webpacker/version'
-
-        Webpacker::VERSION
+        if defined?(Shakapacker)
+          Shakapacker::VERSION
+        elsif defined?(Webpacker)
+          Webpacker::VERSION
+        end
       end
     end
   end


### PR DESCRIPTION
Hi!
### Issue
I'm using `wicked_pdf` in a project where assets are being delivered with `shakapacker` version `7` .
I ran into an issue where the following error message was raised when I tried to use pack asset helpers:
```
cannot load such file -- webpacker/version (LoadError)
```
I've seen that this issue has already been reported here: https://github.com/mileszs/wicked_pdf/issues/1066
### Cause
I've found out that this line was raising the error:
`lib/wicked_pdf/wicked_pdf_helper/assets.rb :237`
```ruby
require 'webpacker/version'
```
Shakapacker started renaming their entire project from `webpacker` to `shakapacker` .
See the changelog for details: https://github.com/shakacode/shakapacker/blob/master/CHANGELOG.md#changed
> _Rename Webpacker to Shakapacker in the entire project including config files, binstubs, environment variables, etc. with a high degree of backward compatibility._
### Fix
A possible fix could have been to just remove the line raising the error. I believe that when `defined?(Webpacker)` is true, we do not need to `require 'webpacker/version'`. It will already be defined.

I figured tho that a more long lasting solution would be to check if either of Shakapcker or Webpacker is defined. In case shakapacker's backward compatibility expires.
### Tests
I did not include any tests in my PR. The current test suite doesn't have the ability to test assets delivered by shakapacker. I believe that the CI test matrix would need to be expanded and the gemfiles would need to be reworked to do so. I've found that to be a lot larger of a fix than what I originally intended to do.