### PR TITLE
Add WickedPdf.configure method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ You can see what flags are supported for the current version in [wkhtmltopdf's a
 If your wkhtmltopdf executable is not on your webserver's path, you can configure it in an initializer:
 
 ```ruby
-WickedPdf.config = {
-  exe_path: '/usr/local/bin/wkhtmltopdf',
-  enable_local_file_access: true
+WickedPdf.configure do |c|
+  c.exe_path = '/usr/local/bin/wkhtmltopdf',
+  c.enable_local_file_access = true
 }
 ```
 

--- a/generators/wicked_pdf/templates/wicked_pdf.rb
+++ b/generators/wicked_pdf/templates/wicked_pdf.rb
@@ -8,23 +8,23 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.config = {
+WickedPdf.configure do |config|
   # Path to the wkhtmltopdf executable: This usually isn't needed if using
   # one of the wkhtmltopdf-binary family of gems.
-  # exe_path: '/usr/local/bin/wkhtmltopdf',
+  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
   #   or
-  # exe_path: Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+  # config.exe_path = Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
 
   # Needed for wkhtmltopdf 0.12.6+ to use many wicked_pdf asset helpers
-  # enable_local_file_access: true,
+  # config.enable_local_file_access = true,
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # layout: 'pdf.html',
+  # config.layout = 'pdf.html',
 
   # Using wkhtmltopdf without an X server can be achieved by enabling the
   # 'use_xvfb' flag. This will wrap all wkhtmltopdf commands around the
   # 'xvfb-run' command, in order to simulate an X server.
   #
-  # use_xvfb: true,
-}
+  # config.use_xvfb = true,
+end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -20,9 +20,17 @@ require 'wicked_pdf/progress'
 class WickedPdf
   DEFAULT_BINARY_VERSION = Gem::Version.new('0.9.9')
   @@config = {}
-  cattr_accessor :config
+  cattr_accessor :config, :silence_deprecations
 
   include Progress
+
+  def self.config=(config)
+    unless @@silence_deprecations
+      ::Kernel.warn "WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead."
+    end
+
+    @@config = config
+  end
 
   def self.configure
     config = OpenStruct.new(@@config)

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -24,6 +24,17 @@ class WickedPdf
 
   include Progress
 
+  def self.configure
+    config = OpenStruct.new(@@config)
+    yield config
+
+    @@config.merge! config.to_h
+  end
+
+  def self.clear_config
+    @@config = {}
+  end
+
   def initialize(wkhtmltopdf_binary_path = nil)
     @binary = Binary.new(wkhtmltopdf_binary_path, DEFAULT_BINARY_VERSION)
   end

--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -25,9 +25,7 @@ class WickedPdf
   include Progress
 
   def self.config=(config)
-    unless @@silence_deprecations
-      ::Kernel.warn "WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead."
-    end
+    ::Kernel.warn 'WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.' unless @@silence_deprecations
 
     @@config = config
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require 'mocha/test_unit'
 require 'wicked_pdf'
 
 Rails.backtrace_cleaner.remove_silencers!
+WickedPdf.silence_deprecations = true
 
 if (assets_dir = Rails.root.join('app/assets')) && File.directory?(assets_dir)
   # Copy CSS file

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -12,7 +12,7 @@ class WickedPdfTest < ActiveSupport::TestCase
       c.test = 'foobar'
     end
 
-    assert WickedPdf.config == { :exe_path => ENV['WKHTMLTOPDF_BIN'] || '/usr/local/bin/wkhtmltopdf', test: 'foobar' }
+    assert WickedPdf.config == { :exe_path => ENV['WKHTMLTOPDF_BIN'] || '/usr/local/bin/wkhtmltopdf', :test => 'foobar' }
   end
 
   test 'should clear config through .clear_config class method' do

--- a/test/unit/wicked_pdf_test.rb
+++ b/test/unit/wicked_pdf_test.rb
@@ -7,6 +7,23 @@ class WickedPdfTest < ActiveSupport::TestCase
     @wp = WickedPdf.new
   end
 
+  test 'should update config through .configure class method' do
+    WickedPdf.configure do |c|
+      c.test = 'foobar'
+    end
+
+    assert WickedPdf.config == { :exe_path => ENV['WKHTMLTOPDF_BIN'] || '/usr/local/bin/wkhtmltopdf', test: 'foobar' }
+  end
+
+  test 'should clear config through .clear_config class method' do
+    backup_config = WickedPdf.config
+
+    WickedPdf.clear_config
+    assert WickedPdf.config == {}
+
+    WickedPdf.config = backup_config
+  end
+
   test 'should generate PDF from html document' do
     pdf = @wp.pdf_from_string HTML_DOCUMENT
     assert pdf.start_with?('%PDF-1.4')


### PR DESCRIPTION
Adds the `WickedPdf.configure` method described in #1089. Also adds a deprecation warning for `WickedPdf.config=` which can be silenced.