### PR TITLE
Fix Propshaft encoding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [master branch] - Unreleased
 ### Breaking Changes
 
+### Fixes
+- [Fix Propshaft encoding issue](https://github.com/mileszs/wicked_pdf/pull/1096)
+
 ## [2.7.0]
 ### New Features
 - [Support Shakapacker 7](https://github.com/mileszs/wicked_pdf/pull/1067)

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -183,7 +183,7 @@ class WickedPdf
             IO.read(pathname)
           end
         else
-          find_asset(source).to_s
+          find_asset(source).to_s.force_encoding('UTF-8')
         end
       end
 


### PR DESCRIPTION
We get the following error after replacing Sprockets with Propshaft:
`ActionView::Template::Error (incompatible character encodings: ASCII-8BIT and UTF-8)`

This fix resolves the issue.

Propshaft::Asset#content returns an ASCII-8BIT encoded string because it's using File::binread under the hood so the encoding needs to be set to UTF-8 if it's a JS or CSS file.