### PR TITLE
Fix webpacker compatibility

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -232,8 +232,10 @@ class WickedPdf
 
       def webpacker_version
         if defined?(Shakapacker)
+          require 'shakapacker/version'
           Shakapacker::VERSION
         elsif defined?(Webpacker)
+          require 'webpacker/version'
           Webpacker::VERSION
         end
       end


### PR DESCRIPTION
As explain in #1098 this PR https://github.com/mileszs/wicked_pdf/pull/1067 broke compatibility with `Webpacker`

## Cause 
The following line has been removed, resulting in an error when trying to access `Webpacker::VERSION`
```ruby
require 'webpacker/version'
```
## Fix
Re add the `require 'webpacker/version'` and for consistency also add `require 'shakapacker/version'` when using `Shakapacker`

## Test
I tested it on our code base and our test suite is green. 
Ideally someone using `Shakapacker` would give this ago as well
