### PR TITLE
Correct syntax for configure block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ You can see what flags are supported for the current version in [wkhtmltopdf's a
 If your wkhtmltopdf executable is not on your webserver's path, you can configure it in an initializer:
 
 ```ruby
-WickedPdf.configure do |c|
-  c.exe_path = '/usr/local/bin/wkhtmltopdf'
-  c.enable_local_file_access = true
-end
+WickedPdf.config ||= {
+  c.exe_path: '/usr/local/bin/wkhtmltopdf',
+  c.enable_local_file_access: true
+}
 ```
 
 For more information about `wkhtmltopdf`, see the project's [homepage](http://wkhtmltopdf.org/).

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ If your wkhtmltopdf executable is not on your webserver's path, you can configur
 
 ```ruby
 WickedPdf.configure do |c|
-  c.exe_path = '/usr/local/bin/wkhtmltopdf',
+  c.exe_path = '/usr/local/bin/wkhtmltopdf'
   c.enable_local_file_access = true
-}
+end
 ```
 
 For more information about `wkhtmltopdf`, see the project's [homepage](http://wkhtmltopdf.org/).


### PR DESCRIPTION
The syntax for the `configure` block in the doc was incorrect.

As far as I can tell `WickedPdf` doesn't support a `configure` block.