### PR TITLE
fix: OpenStruct causes NameError in Rake13.2.0

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -5,6 +5,7 @@ require 'logger'
 require 'digest/md5'
 require 'rbconfig'
 require 'open3'
+require 'ostruct'
 
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
resolved #1109

Loading of "ostruct" depends on Rake, so we need to explicitly load it and resolve the dependency.
Because Rake does not load "ostruct" since version 13.2.0.
https://github.com/ruby/rake/pull/545