### PR TITLE
Fix: Ensure assets without extensions are handled correctly

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -216,7 +216,13 @@ class WickedPdf
         assets = Rails.application.assets_manifest.assets
 
         if File.extname(path).empty?
-          assets.find { |asset, _v| File.basename(asset, File.extname(asset)) == path }&.last
+          assets.find do |asset, _v|
+            directory = File.dirname(asset)
+            asset_path = File.basename(asset, File.extname(asset))
+            asset_path = File.join(directory, asset_path) if directory != '.'
+
+            asset_path == path
+          end&.last
         else
           assets[path]
         end

--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -202,10 +202,23 @@ class WickedPdf
         elsif defined?(Propshaft::Assembly) && Rails.application.assets.is_a?(Propshaft::Assembly)
           PropshaftAsset.new(Rails.application.assets.load_path.find(path))
         elsif Rails.application.respond_to?(:assets_manifest)
-          asset_path = File.join(Rails.application.assets_manifest.dir, Rails.application.assets_manifest.assets[path])
+          relative_asset_path = get_asset_path_from_manifest(path)
+          return unless relative_asset_path
+
+          asset_path = File.join(Rails.application.assets_manifest.dir, relative_asset_path)
           LocalAsset.new(asset_path) if File.file?(asset_path)
         else
           SprocketsEnvironment.find_asset(path, :base_path => Rails.application.root.to_s)
+        end
+      end
+
+      def get_asset_path_from_manifest(path)
+        assets = Rails.application.assets_manifest.assets
+
+        if File.extname(path).empty?
+          assets.find { |asset, _v| File.basename(asset, File.extname(asset)) == path }&.last
+        else
+          assets[path]
         end
       end
 

--- a/test/fixtures/subdirectory/nested.js
+++ b/test/fixtures/subdirectory/nested.js
@@ -1,0 +1,1 @@
+// Nested js

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -26,6 +26,10 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       assert_match %r{data:application\/javascript;base64,.+}, wicked_pdf_asset_base64('wicked')
     end
 
+    test 'wicked_pdf_asset_base64 works with nested files and without file extension when using sprockets' do
+      assert_match %r{data:application\/javascript;base64,.+}, wicked_pdf_asset_base64('subdirectory/nested')
+    end
+
     test 'wicked_pdf_asset_base64 works without file extension when using asset manifest' do
       stub_manifest = OpenStruct.new(
         :dir => Rails.root.join('app/assets'),
@@ -35,6 +39,17 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       Rails.application.stubs(:assets_manifest).returns(stub_manifest)
 
       assert_match %r{data:text\/css;base64,.+}, wicked_pdf_asset_base64('wicked')
+    end
+
+    test 'wicked_pdf_asset_base64 works with nested files and without file extension when using asset manifest' do
+      stub_manifest = OpenStruct.new(
+        :dir => Rails.root.join('app/assets'),
+        :assets => { 'subdirectory/nested.js' => 'javascripts/subdirectory/nested.js' }
+      )
+      Rails.application.stubs(:assets).returns(nil)
+      Rails.application.stubs(:assets_manifest).returns(stub_manifest)
+
+      assert_match %r{data:text\/javascript;base64,.+}, wicked_pdf_asset_base64('subdirectory/nested')
     end
 
     test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in' do

--- a/test/functional/wicked_pdf_helper_assets_test.rb
+++ b/test/functional/wicked_pdf_helper_assets_test.rb
@@ -11,6 +11,10 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
 
   teardown do
     WickedPdf.config = @saved_config
+
+    # @see freerange/mocha#331
+    Rails.application.unstub(:assets)
+    Rails.application.unstub(:assets_manifest)
   end
 
   if Rails::VERSION::MAJOR > 3 || (Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR > 0)
@@ -18,9 +22,43 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
       assert_match %r{data:text\/css;base64,.+}, wicked_pdf_asset_base64('wicked.css')
     end
 
+    test 'wicked_pdf_asset_base64 works without file extension when using sprockets' do
+      assert_match %r{data:application\/javascript;base64,.+}, wicked_pdf_asset_base64('wicked')
+    end
+
+    test 'wicked_pdf_asset_base64 works without file extension when using asset manifest' do
+      stub_manifest = OpenStruct.new(
+        :dir => Rails.root.join('app/assets'),
+        :assets => { 'wicked.css' => 'stylesheets/wicked.css', 'wicked.js' => 'javascripts/wicked.js' }
+      )
+      Rails.application.stubs(:assets).returns(nil)
+      Rails.application.stubs(:assets_manifest).returns(stub_manifest)
+
+      assert_match %r{data:text\/css;base64,.+}, wicked_pdf_asset_base64('wicked')
+    end
+
     test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in' do
       Rails.configuration.assets.expects(:compile => true)
       assert_equal "<style type='text/css'>/* Wicked styles */\n\n</style>",
+                   wicked_pdf_stylesheet_link_tag('wicked')
+    end
+
+    test 'wicked_pdf_stylesheet_link_tag should work without file extension when using sprockets' do
+      Rails.configuration.assets.expects(:compile => true)
+      assert_equal "<style type='text/css'>/* Wicked styles */\n\n</style>",
+                   wicked_pdf_stylesheet_link_tag('wicked')
+    end
+
+    test 'wicked_pdf_stylesheet_link_tag should work without file extension when using asset manifest' do
+      stub_manifest = OpenStruct.new(
+        :dir => Rails.root.join('app/assets'),
+        :assets => { 'wicked.css' => 'stylesheets/wicked.css', 'wicked.js' => 'javascripts/wicked.js' }
+      )
+
+      Rails.application.stubs(:assets).returns(nil)
+      Rails.application.stubs(:assets_manifest).returns(stub_manifest)
+
+      assert_equal "<style type='text/css'>/* Wicked styles */\n</style>",
                    wicked_pdf_stylesheet_link_tag('wicked')
     end
 
@@ -54,6 +92,21 @@ class WickedPdfHelperAssetsTest < ActionView::TestCase
     end
 
     test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in when assets are remote' do
+      stub_request(:get, 'https://www.example.com/wicked.css').to_return(:status => 200, :body => '/* Wicked styles */')
+      expects(:precompiled_or_absolute_asset? => true).twice
+      assert_equal "<style type='text/css'>/* Wicked styles */</style>",
+                   wicked_pdf_stylesheet_link_tag('https://www.example.com/wicked.css')
+    end
+
+    test 'wicked_pdf_stylesheet_link_tag should inline the stylesheets passed in when assets are remote and using asset manifest' do
+      stub_manifest = OpenStruct.new(
+        :dir => Rails.root.join('app/assets'),
+        :assets => { 'wicked.css' => 'stylesheets/wicked.css', 'wicked.js' => 'javascripts/wicked.js' }
+      )
+
+      Rails.application.stubs(:assets).returns(nil)
+      Rails.application.stubs(:assets_manifest).returns(stub_manifest)
+
       stub_request(:get, 'https://www.example.com/wicked.css').to_return(:status => 200, :body => '/* Wicked styles */')
       expects(:precompiled_or_absolute_asset? => true).twice
       assert_equal "<style type='text/css'>/* Wicked styles */</style>",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,11 @@ if (assets_dir = Rails.root.join('app/assets')) && File.directory?(assets_dir)
   source = File.read('test/fixtures/wicked.js')
   File.open(destination, 'w') { |f| f.write(source) }
 
+  Dir.mkdir(js_dir.join('subdirectory')) unless File.directory?(js_dir.join('subdirectory'))
+  destination = js_dir.join('subdirectory/nested.js')
+  source = File.read('test/fixtures/subdirectory/nested.js')
+  File.open(destination, 'w') { |f| f.write(source) }
+
   config_dir = assets_dir.join('config')
   Dir.mkdir(config_dir) unless File.directory?(config_dir)
   source = File.read('test/fixtures/manifest.js')


### PR DESCRIPTION
This PR fixes the issues reported after #1094 and related to the asset manifest implementation not looking for the assets properly.

---
As a side note, this will most likely be my last contribution to this project. The fix itself took me 5 minutes to implement but adding those four simple test cases took... 1.5h. I wish I was joking 🥲

If anyone still has energy it would be great to at least figure out how to upgrade Mocha to the newer version as this one has a bug that prevents stubs from clearing properly (though it would be amazing to get rid of it completely and switch to rspec)