### PR TITLE
Fix for frozen string literal to prepare for ruby 3.4

### DIFF
--- a/lib/wicked_pdf/tempfile.rb
+++ b/lib/wicked_pdf/tempfile.rb
@@ -23,9 +23,9 @@ class WickedPdf
     def read_in_chunks
       rewind
       binmode
-      output_string = ''
-      output_string << read(chunk_size) until eof?
-      output_string
+      chunks = []
+      chunks << read(chunk_size) until eof?
+      chunks.join
     rescue Errno::EINVAL => e
       raise e, file_too_large_message
     end


### PR DESCRIPTION
Cf. https://gist.github.com/fxn/bf4eed2505c76f4fca03ab48c43adc72

Hi, 

This is a simple fix for a case of a string being mutated while frozen ( with `frozen_string_literal` true)

I believe to enable this gem to be compliant with the future in ruby, and following the recommandations of the aforementionned gist, It would be good to enable the frozen string literal RUBYOPTion in CI