### PR TITLE
Fix: add option temp_path for footer

### DIFF
--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -61,7 +61,7 @@ class WickedPdf
           r += make_options(opt_hf, [:line], hf.to_s, :boolean)
           if options[hf] && options[hf][:content]
             @hf_tempfiles = [] unless defined?(@hf_tempfiles)
-            @hf_tempfiles.push(tf = File.new(Dir::Tmpname.create(["wicked_#{hf}_pdf", '.html']) {}, 'w'))
+            @hf_tempfiles.push(tf = File.new(Dir::Tmpname.create(["wicked_#{hf}_pdf", '.html'], options[hf][:temp_path]) {}, 'w'))
             tf.write options[hf][:content]
             tf.flush
             options[hf][:html] = {}


### PR DESCRIPTION
This pr is to fix the problem of not being able to print the footer in the system temp folder

```
Error: Failed to load file:////tmp/wicked_footer_pdf20240605-7-tukdky.html?page=1&section=&sitepage=1&title=&subsection=&frompage=1&subsubsection=&isodate=2024-06-05&topage=8&doctitle=&sitepages=8&webpage=file:////tmp/wicked_pdf20240605-7-9ckxx2.html&time=13:55:56&date=5 Jun 2024, with network status code 203 and http status code 0 - Error opening //tmp/wicked_footer_pdf20240605-7-tukdky.html: No such file or directory\
```