### PR TITLE
Add `ostruct` as dependency for Ruby 3.5.0

### DIFF
--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -29,6 +29,7 @@ DESC
   spec.requirements << 'wkhtmltopdf'
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'ostruct'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'mocha', '= 1.3'


### PR DESCRIPTION
Starting from Ruby 3.5.0, `ostruct` will no longer be included as a default gem. This means that it must be added to the gemspec.

Here is the deprecation message:
```
/Users/garyhtou/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /Users/garyhtou/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of wicked_pdf-2.8.1 to request adding ostruct into its gemspec.
```

Closes https://github.com/mileszs/wicked_pdf/issues/1129