### PR TITLE
Version check hangs on ruby 3 with certain gem combination

### DIFF
--- a/lib/wicked_pdf/binary.rb
+++ b/lib/wicked_pdf/binary.rb
@@ -38,7 +38,9 @@ class WickedPdf
     private
 
     def retrieve_binary_version
-      _stdin, stdout, _stderr = Open3.popen3(@path + ' -V')
+      stdin, stdout, stderr = Open3.popen3(@path + ' -V')
+      stdin.close
+      stderr.close
       parse_version_string(stdout.gets(nil))
     rescue StandardError
       default_version


### PR DESCRIPTION
Close unneeded pipes when wkhtmltopdf checking version.

Unless we close the stdin and stderr pipes in Open3, this command will hang when running under Ruby 3.1 (and possibly ruby 3.0 too).

According to [the documentation](https://docs.ruby-lang.org/en/2.0.0/Open3.html#method-i-popen3) these pipes should be closed explicitly when in block form (like we are using).

Note: This only happens for me when I'm also using a bunch of older/outdated gems (specifically, `eye`, which uses `celluloid`, `celluloid-io`, `kostya-sigar` and `state_machines` gems). If I'm not including these gems (via `ey`) in my project, this problem doesn't occur