### PR TITLE
assets: improve compatibility with Shakapacker 8

### DIFF
--- a/lib/wicked_pdf/wicked_pdf_helper/assets.rb
+++ b/lib/wicked_pdf/wicked_pdf_helper/assets.rb
@@ -112,7 +112,7 @@ class WickedPdf
       end
 
       def wicked_pdf_stylesheet_pack_tag(*sources)
-        return unless defined?(Webpacker)
+        return unless webpacker_class
 
         if running_in_development?
           stylesheet_pack_tag(*sources)
@@ -126,7 +126,7 @@ class WickedPdf
       end
 
       def wicked_pdf_javascript_pack_tag(*sources)
-        return unless defined?(Webpacker)
+        return unless webpacker_class
 
         if running_in_development?
           javascript_pack_tag(*sources)
@@ -163,7 +163,7 @@ class WickedPdf
       end
 
       def wicked_pdf_asset_pack_path(asset)
-        return unless defined?(Webpacker)
+        return unless webpacker_class
 
         if running_in_development?
           asset_pack_path(asset)
@@ -310,23 +310,28 @@ class WickedPdf
       end
 
       def running_in_development?
-        return unless webpacker_version
+        return unless webpacker_class
 
         # :dev_server method was added in webpacker 3.0.0
-        if Webpacker.respond_to?(:dev_server)
-          Webpacker.dev_server.running?
+        if webpacker_class.respond_to?(:dev_server)
+          webpacker_class.dev_server.running?
         else
           Rails.env.development? || Rails.env.test?
         end
       end
 
       def webpacker_version
+        return unless webpacker_class
+
+        require "#{webpacker_class.to_s.downcase}/version"
+        webpacker_class.const_get('VERSION')
+      end
+
+      def webpacker_class
         if defined?(Shakapacker)
-          require 'shakapacker/version'
-          Shakapacker::VERSION
+          Shakapacker
         elsif defined?(Webpacker)
-          require 'webpacker/version'
-          Webpacker::VERSION
+          Webpacker
         end
       end
     end


### PR DESCRIPTION
Make the following methods work with Shakapacker 8 (instead of raising an exception):
- `running_in_development?`
- `wicked_pdf_stylesheet_pack_tag`
- `wicked_pdf_javascript_pack_tag`
- `wicked_pdf_asset_path`

Fix #1133