### PR TITLE
Restore the current gem version

### DIFF
--- a/lib/wicked_pdf/version.rb
+++ b/lib/wicked_pdf/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class WickedPdf
-  VERSION = '2.8.1'
+  VERSION = '2.8.2'
 end


### PR DESCRIPTION
Current master regressed `WickedPdf::VERSION` from the latest released 2.8.2 to 2.8.1, so a build would collide with an older release. Restore 2.8.2.

Verified with 61 tests and 167 assertions on Ruby 4.0.6 and 3.2.11 plus a focused version and package model.