### PR TITLE
Pass version arguments directly to wkhtmltopdf

### DIFF
--- a/lib/wicked_pdf/binary.rb
+++ b/lib/wicked_pdf/binary.rb
@@ -38,10 +38,11 @@ class WickedPdf
     private
 
     def retrieve_binary_version
-      stdin, stdout, stderr = Open3.popen3(@path + ' -V')
-      stdin.close
-      stderr.close
-      parse_version_string(stdout.gets(nil))
+      Open3.popen3(@path, '-V') do |stdin, stdout, stderr, _wait_thread|
+        stdin.close
+        stderr.close
+        return parse_version_string(stdout.gets(nil))
+      end
     rescue StandardError
       default_version
     end


### PR DESCRIPTION
Version discovery concatenates the executable and `-V` into a shell command, so valid executable-path metacharacters are reinterpreted. Pass executable and argument separately to `Open3.popen3`, retaining block cleanup.

This preserves the executable-file contract and intentionally does not adopt command-string behavior proposed by #653. Dual-Ruby suite and focused argv model pass.