### PR TITLE
Preserve progress command arguments and error mode

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -84,6 +84,7 @@ class WickedPdf
 
     if track_progress?(options)
       invoke_with_progress(command, options)
+      err = ''
     else
       _out, err, status = Open3.capture3(*command)
       err = [status.to_s, err].join("\n") if !err.empty? || !status.success?

--- a/lib/wicked_pdf/progress.rb
+++ b/lib/wicked_pdf/progress.rb
@@ -12,7 +12,7 @@ class WickedPdf
     def invoke_with_progress(command, options)
       output = []
       begin
-        PTY.spawn(command.join(' ')) do |stdout, _stdin, pid|
+        PTY.spawn(*command) do |stdout, _stdin, pid|
           begin
             stdout.sync
             stdout.each_line("\r") do |line|
@@ -28,8 +28,11 @@ class WickedPdf
       rescue PTY::ChildExited
         puts 'The child process exited!'
       end
-      err = output.join('\n')
-      raise "#{command} failed (exitstatus 0). Output was: #{err}" unless $CHILD_STATUS && $CHILD_STATUS.exitstatus.zero?
+      err = output.join("\n")
+      exitstatus = $CHILD_STATUS && $CHILD_STATUS.exitstatus
+      raise "#{command} failed (exitstatus #{exitstatus}). Output was: #{err}" unless exitstatus == 0
+
+      err
     end
   end
 end


### PR DESCRIPTION
Progress execution joins argv through a shell, replaces real failures with exit 0, joins output with a literal backslash sequence, and leaves successful `raise_on_all_errors` mode with nil stderr. Use argv PTY execution and preserve real status and output with an explicit successful error value.

Covers open #1043. Dual-Ruby suite and success and failure argv and status models pass.