### PR TITLE
Keep URL render options caller-owned

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -71,6 +71,7 @@ class WickedPdf
   end
 
   def pdf_from_url(url, options = {}) # rubocop:disable Metrics/CyclomaticComplexity
+    options = options.dup
     # merge in global config options
     options.merge!(WickedPdf.config) { |_key, option, _config| option }
     generated_pdf_file = WickedPdf::Tempfile.new('wicked_pdf_generated_file.pdf', options[:temp_path])


### PR DESCRIPTION
Direct `pdf_from_url` deletes keys from the caller options Hash and raises for frozen options. Duplicate the top-level Hash before normalization, matching `pdf_from_string` ownership.

Verified with 61 tests and 167 assertions and a focused mutable and frozen options model on Ruby 4.0.6 and 3.2.11.