### PR TITLE
Preserve colons in basic auth passwords

### DIFF
--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -44,7 +44,7 @@ class WickedPdf
 
     def parse_basic_auth(options)
       if options[:basic_auth]
-        user, passwd = Base64.decode64(options[:basic_auth]).split(':')
+        user, passwd = Base64.decode64(options[:basic_auth]).split(':', 2)
         ['--username', user, '--password', passwd]
       else
         []


### PR DESCRIPTION
Basic-auth parsing splits decoded credentials on every colon, truncating valid passwords that contain colons. Split once so the complete password is retained.

Verified with 61 tests and 167 assertions and a focused colon-bearing credential model on Ruby 4.0.6 and 3.2.11.