### PR TITLE
Scope header temporary files to each render

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -129,6 +129,10 @@ class WickedPdf
   def clean_temp_files
     return unless option_parser.hf_tempfiles.present?
 
-    option_parser.hf_tempfiles.each { |file| File.delete(file) }
+    option_parser.hf_tempfiles.each do |file|
+      file.close unless file.closed?
+      File.delete(file.path) if File.exist?(file.path)
+    end
+    option_parser.hf_tempfiles.clear
   end
 end

--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -11,6 +11,7 @@ class WickedPdf
     end
 
     def parse(options)
+      @hf_tempfiles = []
       [
         parse_extra(options),
         parse_others(options),
@@ -57,17 +58,15 @@ class WickedPdf
         %i[header footer].collect do |hf|
           next if options[hf].blank?
 
-          opt_hf = options[hf]
+          opt_hf = options[hf].dup
           r += make_options(opt_hf, %i[center font_name left right], hf.to_s)
           r += make_options(opt_hf, %i[font_size spacing], hf.to_s, :numeric)
           r += make_options(opt_hf, [:line], hf.to_s, :boolean)
           if options[hf] && options[hf][:content]
-            @hf_tempfiles = [] unless defined?(@hf_tempfiles)
             @hf_tempfiles.push(tf = File.new(Dir::Tmpname.create(["wicked_#{hf}_pdf", '.html']) {}, 'w'))
             tf.write options[hf][:content]
             tf.flush
-            options[hf][:html] = {}
-            options[hf][:html][:url] = "file:///#{tf.path}"
+            opt_hf[:html] = { :url => "file:///#{tf.path}" }
           end
           unless opt_hf[:html].blank?
             r += make_option("#{hf}-html", opt_hf[:html][:url]) unless opt_hf[:html][:url].blank?
@@ -85,7 +84,6 @@ class WickedPdf
       if argument.is_a?(Pathname) || (arg[0, 4] == 'http')
         [valid_option('cover'), arg]
       else # HTML content
-        @hf_tempfiles ||= []
         @hf_tempfiles << tf = WickedPdf::Tempfile.new('wicked_cover_pdf.html')
         tf.write arg
         tf.flush


### PR DESCRIPTION
A reused option parser retains already-deleted header and footer temporary files, causing later cleanup failures, and nested header content is deleted from caller input. Scope temporary files to one parse, close and delete idempotently, clear state, and parse a local nested-options copy.

Related to #1031 and #1119 but fixes cached-parser state and caller ownership. Dual-Ruby suite and repeated-render model pass.