### PR TITLE
Forward nested header file render options

### DIFF
--- a/lib/wicked_pdf/pdf_helper.rb
+++ b/lib/wicked_pdf/pdf_helper.rb
@@ -119,7 +119,7 @@ class WickedPdf
           :assigns => options[hf][:html][:assigns]
         }
         render_opts[:locals] = options[hf][:html][:locals] if options[hf][:html][:locals]
-        render_opts[:file] = options[hf][:html][:file] if options[:file]
+        render_opts[:file] = options[hf][:html][:file] if options[hf][:html][:file]
         tf.write render_to_string(render_opts)
         tf.flush
         options[hf][:html][:url] = "file:///#{tf.path}"


### PR DESCRIPTION
Nested `header: { html: { file: ... } }` is forwarded only when an unrelated top-level `file` option exists. Check the nested value itself.

Verified with 61 tests and 167 assertions and a focused nested header-file model on Ruby 4.0.6 and 3.2.11.