### PR TITLE
Correct the minimum supported Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Wicked PDF uses the shell utility [wkhtmltopdf](http://wkhtmltopdf.org) to serve a PDF file to a user from HTML.  In other words, rather than dealing with a PDF generation DSL of some sort, you simply write an HTML view as you would normally, then let Wicked PDF take care of the hard stuff.
 
-_Wicked PDF has been verified to work on Ruby versions 2.2 through 3.2; Rails 4 through 7.0_
+_Wicked PDF has been verified to work on Ruby versions 2.3 through 3.2; Rails 4 through 7.0_
 
 ### Installation
 

--- a/wicked_pdf.gemspec
+++ b/wicked_pdf.gemspec
@@ -21,7 +21,7 @@ DESC
     'changelog_uri' => 'https://github.com/mileszs/wicked_pdf/blob/master/CHANGELOG.md'
   }
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.2')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3')
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
Package metadata and README claim Ruby 2.2 support, but shipped source uses Ruby 2.3 safe-navigation syntax. Declare the truthful `>= 2.3` minimum.

Covers open #1082. The candidate gem builds with 46 paths and dual-Ruby suites pass.