### PR TITLE
Remove the stale tempfile require

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,2 +1,1 @@
 require 'wicked_pdf'
-require 'wicked_pdf_tempfile'


### PR DESCRIPTION
Packaged `init.rb` requires nonexistent `wicked_pdf_tempfile` after `wicked_pdf` already loads the actual tempfile class, so legacy initialization raises `LoadError`. Remove the stale second require.

Covers closed #399. Dual-Ruby suite and focused packaged-initializer model pass.