### PR TITLE
Load Base64 before parsing authentication

### DIFF
--- a/lib/wicked_pdf/option_parser.rb
+++ b/lib/wicked_pdf/option_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'base64'
+
 class WickedPdf
   class OptionParser
     BINARY_VERSION_WITHOUT_DASHES = Gem::Version.new('0.12.0')


### PR DESCRIPTION
Standalone option-parser authentication calls `Base64.decode64` without loading Base64, raising `NameError` unless another dependency happened to load it first. Require `base64` at the parser boundary.

Verified with 61 tests and 167 assertions and a standalone authentication model on Ruby 4.0.6 and 3.2.11.